### PR TITLE
[Feat] Category

### DIFF
--- a/src/components/ArticleBox/ArticleBoxCategoryLink.tsx
+++ b/src/components/ArticleBox/ArticleBoxCategoryLink.tsx
@@ -1,0 +1,43 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import { Link } from 'gatsby'
+import { FC } from 'react'
+
+type ArticleCategoryLinkProps = {
+  major?: string
+  minor?: string
+}
+
+const style = css`
+  color: skyblue;
+  padding-left: 3px;
+  font-size: 0.8rem;
+  padding-bottom: 0.2rem;
+`
+
+const ArticleBoxCategoryLink: FC<ArticleCategoryLinkProps> = ({
+  major,
+  minor,
+}) => {
+  return (
+    <div css={style}>
+      <Link to="/posts">total</Link>
+      {major ? (
+        <text>
+          {' > '}
+          <Link to={`/posts/${major}`}>{major}</Link>
+        </text>
+      ) : null}
+
+      {minor ? (
+        <text>
+          {' > '}
+          <Link to={`/posts/${major}/${minor}`}>{minor} </Link>
+        </text>
+      ) : null}
+    </div>
+  )
+}
+
+export default ArticleBoxCategoryLink

--- a/src/components/ArticleBox/ArticleBoxTitle.tsx
+++ b/src/components/ArticleBox/ArticleBoxTitle.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import styled from '@emotion/styled'
+import { Link } from 'gatsby'
+import { FC } from 'react'
+
+export type ArticleBoxTitleProps = {
+  slug: string
+  title: string
+}
+
+const style = css`
+  display: inline-block;
+`
+
+const TitleWrapper = styled.h2`
+  margin: 0;
+`
+
+const ArticleBoxTitle: FC<ArticleBoxTitleProps> = ({ slug, title }) => {
+  return (
+    <Link css={style} to={'/posts' + slug}>
+      <TitleWrapper>{title}</TitleWrapper>
+    </Link>
+  )
+}
+
+export default ArticleBoxTitle

--- a/src/components/ArticleBox/index.tsx
+++ b/src/components/ArticleBox/index.tsx
@@ -1,0 +1,37 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import styled from '@emotion/styled'
+import { FC } from 'react'
+import { MdxNode } from 'types/mdx-types'
+import ArticleBoxTitle from './ArticleBoxTitle'
+import { GRAY } from 'styles/Color'
+import ArticleCategoryLink from './ArticleCategoryLink'
+
+const style = css`
+  width: 600px;
+  margin: 3rem 0 3rem 0;
+`
+
+const CreatedAt = styled.div`
+  color: ${GRAY};
+  font-size: 0.8rem;
+  margin-top: 0.5rem;
+`
+
+const ArticleBox: FC<MdxNode> = ({
+  fields: { slug, category },
+  frontmatter: { title, createdAt },
+  excerpt,
+}) => {
+  return (
+    <div css={style}>
+      <ArticleCategoryLink {...category} />
+      <ArticleBoxTitle slug={slug} title={title} />
+      <div>{excerpt}</div>
+      <CreatedAt>{createdAt}</CreatedAt>
+    </div>
+  )
+}
+
+export default ArticleBox

--- a/src/components/Categories/cells/CategoryCell.tsx
+++ b/src/components/Categories/cells/CategoryCell.tsx
@@ -1,0 +1,33 @@
+/** @jsx jsx */
+
+import { jsx, css } from '@emotion/react'
+import { Link } from 'gatsby'
+import { CategoryTreeObject } from 'hooks/CategoryTree'
+import { FC } from 'react'
+
+type CategoryCellProps = {
+  depth?: number
+  category: CategoryTreeObject
+}
+
+const style = (depth: number) =>
+  css({
+    marginLeft: `${depth * 5}px`,
+  })
+
+const CategoryCell: FC<CategoryCellProps> = ({ depth = 0, category }) => {
+  return (
+    <Link to={'/posts' + category.slug}>
+      <div css={style(depth)}>
+        <div>
+          {category.name}: {category.count}
+        </div>
+        {category.sub.map(cat => {
+          return <CategoryCell depth={depth + 1} category={cat} />
+        })}
+      </div>
+    </Link>
+  )
+}
+
+export default CategoryCell

--- a/src/components/Categories/index.tsx
+++ b/src/components/Categories/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { getCategoryTree } from 'hooks/categoryQueries'
+import CategoryCell from './cells/CategoryCell'
+
+const Categories = () => {
+  const root = getCategoryTree()
+  return (
+    <div>
+      <CategoryCell category={root} />
+    </div>
+  )
+}
+
+export default Categories

--- a/src/templates/CategoryPage.tsx
+++ b/src/templates/CategoryPage.tsx
@@ -1,0 +1,63 @@
+import ArticleBox from 'components/ArticleBox'
+import Layout from 'components/Layout'
+import { graphql, PageProps } from 'gatsby'
+import React, { FC } from 'react'
+import { AllMdxQuery, MdxNode } from '../@types/mdx-types'
+
+export type CategoryPageContext = {
+  major?: string
+  minor?: string
+}
+
+const CategoryPage: FC<PageProps<AllMdxQuery, CategoryPageContext>> = ({
+  data,
+  pageContext,
+}) => {
+  const articles = filterArticleByCategories(data.allMdx.nodes, pageContext)
+
+  return (
+    <Layout>
+      {articles.map(article => {
+        return <ArticleBox {...article} />
+      })}
+    </Layout>
+  )
+}
+
+export default CategoryPage
+
+export function filterArticleByCategories(
+  nodes: MdxNode[],
+  pageContext: CategoryPageContext,
+) {
+  const { major, minor } = pageContext
+  return nodes
+    .filter(node => (major ? major === node.fields.category.major : true))
+    .filter(node => (minor ? minor === node.fields.category.minor : true))
+}
+
+export const query = graphql`
+  query allMdx {
+    allMdx(sort: { frontmatter: { createdAt: DESC } }) {
+      nodes {
+        id
+        fields {
+          slug
+          category {
+            major
+            minor
+            slug
+          }
+        }
+        frontmatter {
+          createdAt(formatString: "MMMM DD, YYYY")
+          slug
+          tags
+          title
+          updatedAt
+        }
+        excerpt(pruneLength: 150)
+      }
+    }
+  }
+`


### PR DESCRIPTION
# 작업 개요

<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
- onCreateNode -> 카테고리 생성
- 카테고리 페이지 구현
- 좌측 카테고리 LeftStack 구현 

# 이슈 티켓

<!-- ex) 작업한 이슈를 태그하세요. -->

- b3abd70 (category 생성 커밋)
- #10 

# 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정

# 작업 상세 내용

<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

카테고리 노드 및 페이지 생성 (b3abd704cdbc0db5baf2efef6741e0b817c4a062)
- gatsby-node.ts
  - MdxNode 에 대해 Category 항목 추가
  - MdxNode에 대해 Category 페이지 추가
- node 추가를 위한 편의 메서드 생성 (appendNode.ts)
- CategoryTree
  - DAO 상위 레이어에서 이용할 수 있는 카테고리 클래스 정의
- slugify 편의 메서드 생성

카테고리 사이드바 LeftStack 

카테고리 페이지
- 일단은 기존 Layout 컴포넌트 이용
  - 추후에 CategoryPageLayout으로 페이지 별로 적용

# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
