### PR TITLE
[Feat] Article Page

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -53,7 +53,12 @@ const config: GatsbyConfig = {
       options: {
         extensions: [`.mdx`, `.md`],
         gatsbyRemarkPlugins: [
-          `gatsby-remark-autolink-headers`,
+          {
+            resolve: `gatsby-remark-autolink-headers`,
+            options: {
+              className: 'header-links',
+            },
+          },
           {
             resolve: 'gatsby-remark-prismjs',
             options: {

--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -27,6 +27,8 @@ export const onCreateWebpackConfig: GatsbyNode['onCreateWebpackConfig'] = ({
         hooks: path.resolve(__dirname, 'src/hooks'),
         types: path.resolve(__dirname, 'src/@types'),
         styles: path.resolve(__dirname, 'src/styles'),
+        contexts: path.resolve(__dirname, 'src/contexts'),
+        datastructures: path.resolve(__dirname, 'src/datastructures'),
       },
     },
   })

--- a/src/@types/graphql-types.d.ts
+++ b/src/@types/graphql-types.d.ts
@@ -1393,7 +1393,6 @@ type Mdx = Node & {
   readonly excerpt: Maybe<Scalars['String']>;
   readonly fields: Maybe<MdxFields>;
   readonly frontmatter: Maybe<MdxFrontmatter>;
-  readonly gatsbyPath: Maybe<Scalars['String']>;
   readonly id: Scalars['ID'];
   readonly internal: Internal;
   readonly parent: Maybe<Node>;
@@ -1403,11 +1402,6 @@ type Mdx = Node & {
 
 type Mdx_excerptArgs = {
   pruneLength?: InputMaybe<Scalars['Int']>;
-};
-
-
-type Mdx_gatsbyPathArgs = {
-  filePath: InputMaybe<Scalars['String']>;
 };
 
 
@@ -1466,7 +1460,6 @@ type MdxFieldSelector = {
   readonly excerpt: InputMaybe<FieldSelectorEnum>;
   readonly fields: InputMaybe<MdxFieldsFieldSelector>;
   readonly frontmatter: InputMaybe<MdxFrontmatterFieldSelector>;
-  readonly gatsbyPath: InputMaybe<FieldSelectorEnum>;
   readonly id: InputMaybe<FieldSelectorEnum>;
   readonly internal: InputMaybe<InternalFieldSelector>;
   readonly parent: InputMaybe<NodeFieldSelector>;
@@ -1523,7 +1516,6 @@ type MdxFilterInput = {
   readonly excerpt: InputMaybe<StringQueryOperatorInput>;
   readonly fields: InputMaybe<MdxFieldsFilterInput>;
   readonly frontmatter: InputMaybe<MdxFrontmatterFilterInput>;
-  readonly gatsbyPath: InputMaybe<StringQueryOperatorInput>;
   readonly id: InputMaybe<StringQueryOperatorInput>;
   readonly internal: InputMaybe<InternalFilterInput>;
   readonly parent: InputMaybe<NodeFilterInput>;
@@ -1629,7 +1621,6 @@ type MdxSortInput = {
   readonly excerpt: InputMaybe<SortOrderEnum>;
   readonly fields: InputMaybe<MdxFieldsSortInput>;
   readonly frontmatter: InputMaybe<MdxFrontmatterSortInput>;
-  readonly gatsbyPath: InputMaybe<SortOrderEnum>;
   readonly id: InputMaybe<SortOrderEnum>;
   readonly internal: InputMaybe<InternalSortInput>;
   readonly parent: InputMaybe<NodeSortInput>;
@@ -1921,7 +1912,6 @@ type Query_mdxArgs = {
   excerpt: InputMaybe<StringQueryOperatorInput>;
   fields: InputMaybe<MdxFieldsFilterInput>;
   frontmatter: InputMaybe<MdxFrontmatterFilterInput>;
-  gatsbyPath: InputMaybe<StringQueryOperatorInput>;
   id: InputMaybe<StringQueryOperatorInput>;
   internal: InputMaybe<InternalFilterInput>;
   parent: InputMaybe<NodeFilterInput>;

--- a/src/@types/mdx-types.d.ts
+++ b/src/@types/mdx-types.d.ts
@@ -41,3 +41,9 @@ export type MdxFrontmatter = {
   createdAt: string
   updatedAt: string
 }
+
+export type MdxTableOfContent = {
+  url?: string
+  title?: string
+  items?: MdxTableOfContent[]
+}

--- a/src/components/ArticleBox/index.tsx
+++ b/src/components/ArticleBox/index.tsx
@@ -6,7 +6,7 @@ import { FC } from 'react'
 import { MdxNode } from 'types/mdx-types'
 import ArticleBoxTitle from './ArticleBoxTitle'
 import { GRAY } from 'styles/Color'
-import ArticleCategoryLink from './ArticleCategoryLink'
+import ArticleBoxCategoryLink from './ArticleBoxCategoryLink'
 
 const style = css`
   width: 600px;
@@ -26,7 +26,7 @@ const ArticleBox: FC<MdxNode> = ({
 }) => {
   return (
     <div css={style}>
-      <ArticleCategoryLink {...category} />
+      <ArticleBoxCategoryLink {...category} />
       <ArticleBoxTitle slug={slug} title={title} />
       <div>{excerpt}</div>
       <CreatedAt>{createdAt}</CreatedAt>

--- a/src/components/Layout/ArticleLayout.tsx
+++ b/src/components/Layout/ArticleLayout.tsx
@@ -1,0 +1,16 @@
+import TableOfContents from 'components/RightStack/TableOfContents'
+import React, { FC } from 'react'
+import { ChildrenProps } from 'types/react-types'
+import Layout from '.'
+
+type ArticleLayoutProps = {} & ChildrenProps
+
+const layoutProps = {
+  rightStack: <TableOfContents />,
+}
+
+const ArticleLayout: FC<ArticleLayoutProps> = ({ children }) => {
+  return <Layout {...layoutProps}>{children}</Layout>
+}
+
+export default ArticleLayout

--- a/src/components/RightStack/TableOfContents/cells/TOCTitle.tsx
+++ b/src/components/RightStack/TableOfContents/cells/TOCTitle.tsx
@@ -1,0 +1,30 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import { ArticleContext } from 'contexts/article/ArticleContext'
+import { Link } from 'gatsby'
+import { FC, useContext } from 'react'
+
+type TOCTitleProps = {
+  title?: string
+  url?: string
+}
+
+const style = css`
+  :hover {
+    color: black;
+  }
+`
+const TOCTitle: FC<TOCTitleProps> = ({ title, url }) => {
+  const {
+    fields: { slug },
+  } = useContext(ArticleContext)
+
+  return (
+    <Link css={style} to={`/posts` + slug + url}>
+      {title}
+    </Link>
+  )
+}
+
+export default TOCTitle

--- a/src/components/RightStack/TableOfContents/cells/TableOfContentsCell.tsx
+++ b/src/components/RightStack/TableOfContents/cells/TableOfContentsCell.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import { FC } from 'react'
+
+import { LIGHT_GRAY } from 'styles/Color'
+import TableNode from 'datastructures/tableOfContents/TableNode'
+import TOCTitle from './TOCTitle'
+
+type TableOfContentsCellProps = {
+  data: TableNode
+  depth?: number
+}
+
+const style = (depth: number, activated: boolean) =>
+  css`
+    margin-left: ${depth * 5}px;
+    color: ${activated ? 'black' : LIGHT_GRAY};
+    font-size: ${activated ? '1.1rem' : '1rem'};
+    transition: color 0.2s ease, font-size 0.2s ease;
+  `
+
+const TableOfContentsCell: FC<TableOfContentsCellProps> = ({
+  data,
+  depth = 0,
+}) => {
+  return (
+    <div css={style(data.depth, data.isActivated())}>
+      <TOCTitle {...data} />
+      {data.items
+        ? data.items.map(item => (
+            <TableOfContentsCell data={item} depth={depth + 1} />
+          ))
+        : null}
+    </div>
+  )
+}
+
+export default TableOfContentsCell

--- a/src/components/RightStack/TableOfContents/index.tsx
+++ b/src/components/RightStack/TableOfContents/index.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import { FC, useContext, useState } from 'react'
+
+import { ArticleContext } from 'contexts/article/ArticleContext'
+import useTableOfContentsObserver from 'hooks/useTableOfContentsObserver'
+
+import TableOfContentsCell from './cells/TableOfContentsCell'
+
+type TableOfContentsProps = {}
+
+const style = css`
+  position: -webkit-sticky;
+  position: sticky;
+  align-self: start;
+  top: 5rem;
+  max-height: calc(100vh - 5rem);
+  overflow: auto;
+`
+const TableOfContents: FC<TableOfContentsProps> = () => {
+  useTableOfContentsObserver()
+  const { tableOfContents } = useContext(ArticleContext)
+
+  return (
+    <div css={style}>
+      <TableOfContentsCell data={tableOfContents!.root} />
+    </div>
+  )
+}
+
+export default TableOfContents

--- a/src/contexts/article/ArticleContext.ts
+++ b/src/contexts/article/ArticleContext.ts
@@ -1,0 +1,15 @@
+import TableOfContentTree from 'datastructures/tableOfContents/TableOfContentTree'
+import React from 'react'
+import { MdxField, MdxFrontmatter } from 'types/mdx-types'
+
+interface ArticleContextProps {
+  frontmatter: MdxFrontmatter
+  tableOfContents: TableOfContentTree
+  fields: MdxField
+
+  activateTarget: (url: string) => void
+}
+
+export const ArticleContext = React.createContext<ArticleContextProps>(
+  {} as ArticleContextProps,
+)

--- a/src/contexts/article/ArticleContextProvider.tsx
+++ b/src/contexts/article/ArticleContextProvider.tsx
@@ -1,0 +1,41 @@
+import { FC, useState } from 'react'
+import { MdxField, MdxFrontmatter, MdxTableOfContent } from 'types/mdx-types'
+import { ChildrenProps } from 'types/react-types'
+import { ArticleContext } from './ArticleContext'
+import TableOfContentTree from 'datastructures/tableOfContents/TableOfContentTree'
+
+type ArticlePageQueryType = {
+  mdx: {
+    id: string
+    fields: MdxField
+    frontmatter: MdxFrontmatter
+    tableOfContents: MdxTableOfContent
+  }
+}
+
+type ArticleContextProviderProps = {
+  data: ArticlePageQueryType
+} & ChildrenProps
+
+const ArticleContextProvider: FC<ArticleContextProviderProps> = ({
+  data,
+  children,
+}) => {
+  const tableOfContentTree = new TableOfContentTree(data.mdx.tableOfContents)
+  const [tableOfContents, mutateTree] =
+    useState<TableOfContentTree>(tableOfContentTree)
+
+  const activateTarget = (url: string) => {
+    mutateTree(prev => prev.activate(url))
+  }
+
+  return (
+    <ArticleContext.Provider
+      value={{ ...data.mdx, tableOfContents, activateTarget }}
+    >
+      {children}
+    </ArticleContext.Provider>
+  )
+}
+
+export default ArticleContextProvider

--- a/src/datastructures/tableOfContents/TableNode.ts
+++ b/src/datastructures/tableOfContents/TableNode.ts
@@ -1,0 +1,45 @@
+import { MdxTableOfContent } from 'types/mdx-types'
+import TableOfContentTree from './TableOfContentTree'
+
+export default class TableNode {
+  readonly url?: string
+  readonly title?: string
+  readonly items: TableNode[] = new Array()
+  private activated: boolean = false
+
+  constructor(
+    private motherTree: TableOfContentTree,
+    tableOfContents: MdxTableOfContent,
+    readonly depth: number = 0,
+  ) {
+    this.url = tableOfContents.url
+    this.title = tableOfContents.title
+    this._appendItems(tableOfContents.items)
+    this._mapDictionaryToMotherTree()
+  }
+
+  public isActivated() {
+    return this.activated
+  }
+
+  public activate() {
+    this.activated = true
+  }
+
+  public deactivate() {
+    this.activated = false
+  }
+
+  private _appendItems(items?: MdxTableOfContent[]) {
+    items?.map(table => {
+      const childTable = new TableNode(this.motherTree, table, this.depth + 1)
+      this.items.push(childTable)
+    })
+  }
+
+  private _mapDictionaryToMotherTree() {
+    if (this.url) {
+      this.motherTree.dictionary.set(this.url, this)
+    }
+  }
+}

--- a/src/datastructures/tableOfContents/TableOfContentTree.ts
+++ b/src/datastructures/tableOfContents/TableOfContentTree.ts
@@ -1,0 +1,49 @@
+import { MdxTableOfContent } from '../../@types/mdx-types'
+import TableNode from './TableNode'
+
+export default class TableOfContentTree {
+  readonly dictionary: Map<string, TableNode> = new Map()
+  readonly root: TableNode
+  public activatedNode?: TableNode
+
+  constructor(tableOfContents: MdxTableOfContent) {
+    this.root = new TableNode(this, tableOfContents)
+  }
+
+  activate(url: string) {
+    this.activateNewNodeIfExists(url)
+    return this
+  }
+
+  private activateNewNodeIfExists(url: string) {
+    try {
+      const currentNode = this.findTableNodeOrThrow(url)
+      this.deactivateCurrentActivatedNode()
+      this.activateNewNode(currentNode)
+    } catch (e) {
+      console.log(`ERROR: ${(e as Error).message}`)
+    }
+  }
+
+  private deactivateCurrentActivatedNode() {
+    this.activatedNode?.deactivate()
+  }
+
+  private activateNewNode(node: TableNode) {
+    this.activatedNode = node
+    this.activatedNode.activate()
+  }
+
+  private findTableNodeOrThrow(url: string) {
+    const key = this.decodeBase64URLEncoding(url)
+    if (this.dictionary.has(key)) {
+      return this.dictionary.get(key)!
+    } else {
+      throw new Error(`해당 key: ${key}에 대한 link를 찾지 못함.`)
+    }
+  }
+
+  private decodeBase64URLEncoding(url: string) {
+    return decodeURIComponent(url)
+  }
+}

--- a/src/hooks/createArticlePages.ts
+++ b/src/hooks/createArticlePages.ts
@@ -1,0 +1,56 @@
+import { AllMdxQuery } from '../@types/mdx-types'
+import { PageGraphQL } from '../@types/nodeapi-types'
+import { CreatePagesArgs } from './createCategoryPages'
+import { resolve } from 'path'
+
+export const createArticlePages = async (args: CreatePagesArgs) => {
+  const {
+    actions: { createPage },
+    graphql,
+  } = args
+
+  const postTemplate = resolve(`src/templates/ArticlePage.tsx`)
+  const results = await getAllMdx(graphql)
+  results.forEach(node => {
+    createPage({
+      path: 'posts' + node.fields.slug,
+      component: `${postTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
+      context: {
+        id: node.id,
+      },
+    })
+  })
+}
+
+const getAllMdx = async (graphql: PageGraphQL) => {
+  const results = (await graphql(`
+    query {
+      allMdx(sort: { frontmatter: { createdAt: DESC } }) {
+        nodes {
+          id
+          fields {
+            slug
+            category {
+              major
+              minor
+              slug
+            }
+          }
+          frontmatter {
+            createdAt(formatString: "MMM DD YYYY")
+            slug
+            tags
+            title
+            updatedAt
+          }
+          excerpt(pruneLength: 250)
+          internal {
+            contentFilePath
+          }
+        }
+      }
+    }
+  `)) as { data: AllMdxQuery }
+
+  return results.data.allMdx.nodes
+}

--- a/src/hooks/useTableOfContentsObserver.ts
+++ b/src/hooks/useTableOfContentsObserver.ts
@@ -1,0 +1,48 @@
+import { ArticleContext } from 'contexts/article/ArticleContext'
+import { useContext, useEffect, useState } from 'react'
+
+export default function useTableOfContentsObserver() {
+  const { activateTarget } = useContext(ArticleContext)
+  const [, triggerRerender] = useState<string>()
+
+  const observerCallback: IntersectionObserverCallback = entries => {
+    activateCurrentIndex(entries)
+  }
+
+  const observerOptions: IntersectionObserverInit = {
+    root: null,
+    rootMargin: '0px 0px -95% 0px',
+    threshold: 1,
+  }
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(observerCallback, observerOptions)
+    const headerLinks = document.querySelectorAll('.header-links')
+    headerLinks.forEach(headerLink => observer.observe(headerLink))
+
+    return () => observer.disconnect()
+  }, [])
+
+  function activateCurrentIndex(entries: IntersectionObserverEntry[]) {
+    if (entries.length > 0) {
+      const currentEntry = entries[0]
+      activateIndex(currentEntry)
+    }
+  }
+
+  function activateIndex(entry: IntersectionObserverEntry) {
+    const url = retrieveHrefFromEntry(entry)
+    activateIfHrefExistsAndRerender(url)
+  }
+
+  function retrieveHrefFromEntry(entry: IntersectionObserverEntry) {
+    return entry.target.getAttribute('href')
+  }
+
+  function activateIfHrefExistsAndRerender(url: string | null) {
+    if (url) {
+      activateTarget(url)
+      triggerRerender(url)
+    }
+  }
+}

--- a/src/pages/posts/{Mdx.frontmatter__slug}.tsx
+++ b/src/pages/posts/{Mdx.frontmatter__slug}.tsx
@@ -1,7 +1,0 @@
-import React from 'react'
-
-const BlogPostPage = () => {
-  return <div>BlogPostPage</div>
-}
-
-export default BlogPostPage

--- a/src/styles/Color.ts
+++ b/src/styles/Color.ts
@@ -1,0 +1,2 @@
+export const GRAY = '#626262'
+export const LIGHT_GRAY = '#737C84'

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,12 @@
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   font-family: 'Noto Sans', sans-serif;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
 }

--- a/src/templates/ArticlePage.tsx
+++ b/src/templates/ArticlePage.tsx
@@ -1,0 +1,48 @@
+import ArticleLayout from 'components/Layout/ArticleLayout'
+import MarkdownWrapper from 'components/MarkdownWrapper'
+import ArticleContextProvider from 'contexts/article/ArticleContextProvider'
+import { graphql } from 'gatsby'
+import React from 'react'
+
+// @ts-ignore
+const ArticlePage = ({ data, children }) => {
+  return (
+    <ArticleContextProvider data={data}>
+      <ArticleLayout>
+        <div>
+          <h1>{data.mdx.frontmatter.title}</h1>
+          <div>Post Date: {data.mdx.frontmatter.createdAt}</div>
+          <MarkdownWrapper>{children}</MarkdownWrapper>
+        </div>
+      </ArticleLayout>
+    </ArticleContextProvider>
+  )
+}
+
+export default ArticlePage
+
+export const query = graphql`
+  query ($id: String) {
+    mdx(id: { eq: $id }) {
+      id
+      body
+      excerpt
+      fields {
+        category {
+          major
+          minor
+          slug
+        }
+        slug
+      }
+      frontmatter {
+        createdAt(formatString: "MMM DD, YYYY")
+        slug
+        tags
+        title
+        updatedAt
+      }
+      tableOfContents
+    }
+  }
+`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,9 @@
       "utils/*": ["./utils/*"],
       "hooks/*": ["./hooks/*"],
       "types/*": ["./@types/*"],
-      "styles/*": ["./styles/*"]
+      "styles/*": ["./styles/*"],
+      "contexts/*": ["./contexts/*"],
+      "datastructures/*": ["./datastructures/*"]
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */


### PR DESCRIPTION
# 작업 개요

<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->

- 글 전문을 확인하는 ArticlePage 생성
  - FileSystemRoute API vs createPage API 
- 글 목차를 확인하는 Table Of Content 생성
  - Intersection Observer API 이용
- ArticlePage의 PageQuery를 spread하는 context 생성

# 이슈 티켓

<!-- ex) 작업한 이슈를 태그하세요. -->
- #15 

# 작업 분류

- [ ] 버그 수정
- [v] 신규 기능
- [v] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [v] 설정

# 작업 상세 내용

<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

## ArticleCategoryLink 이름변경 (52f3f3c7cbcc1b7bfc77fc7a946d83d150b32c3d)
Article 페이지의 컴포넌트 네이밍과 헷갈릴 것 같아 이름을 `ArticleBoxCategoryLink`로 변경해서 적용.

## createPage API를 이용해 article 페이지 생성 (79fde24c2dab6ba6581fac2c735eae36044f9afc)
- 기존의 FileSystemRoute API를 이용한 page/하위의 파일 제거

FileSystemRoute API의 경우 원하는 slug를 이용하기 힘들었다.
- FileSystemRoute API가 uri를 slugi화 할 때 내부적으로 의존하고 있는 slugify 라이브러리
  - 기본적으로 한글을 허용하지 않음. (공백으로 변환)
  - 커스텀할 수 없음.
  - slug field를 지정하고 아예 slugify를 꺼버리려 했는데 이것도 불가.

위와 같은 이유로  FileSystemRoute API 대신 gatsby의 node api를 이용해 수동으로 페이지 생성.

## 글 목차를 위한 자료구조 구현 (ae331ff8a6a07f19c3a8452d52df79381fb4683f)
- ArticlePage의 RightStack에 들어갈 글 목차를 위한 자료구조
- 현재 focusing 하고 있는 node를 갱신, 조회할 수 있는 Tree 자료구조.

## ArticlePage에 대한 Context 생성 (113dde11f0b10abb8e98deefc7cd3ea9eb5355dd)
- React Context API 이용
1. 해당 PageQuery를 통해 가져온 데이터
2. TableOfContentTree (PageQuery를 통해 가져온 값을 이용해 tree initialization)
 - pagequery에서 가져온 값은 gatsby-remark-autolink-headers 플러그인에서 제공
3. tree의 state를 변환할 수 있는 메서드
를 제공하는 context.

## useTableOfContentObserver 훅 구현 (6ead7e460da603889dbfff9a7fecba01e1e871b6)
   - Intersection Observer API 이용
   - root section을 intersect하는 autolink가 발생할 때마다
     - context의 TOC tree의 현재 active된 node를 갱신해준다.
     - 그런데 context에서 제공한 Dispatch 메서드 만으로는 Re-rendering이 안되길래 일단 state를 하나 더 만듬...
     - 결국 hook이 매 state 갱신마다 다시 trigger되어 Intersection Observer가 계속 재생성되는 것 같긴하지만 이 부분은 나중에 개선하기로 하자..

   - gatsby-remark-autolink-headers 설정
     - 생성되는 a tag의 class를 header-links로 지정

## ArticlePage 생성 (482af9ee97a0c2e7174761bc82d5c24f073143cf)
- ArticlePage
- ArticlePage를 위한 ArticleLayout (Layout 상속)
- RightStack에 들어갈 TableOfContent
-  기타 스타일링


# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
