### PR TITLE
[Feat] Context API 적용지점 변경, 카테고리 사이드바 활성화 

### DIFF
--- a/src/components/ArticleBox/ArticleBoxCategoryLink.tsx
+++ b/src/components/ArticleBox/ArticleBoxCategoryLink.tsx
@@ -1,6 +1,7 @@
 /** @jsx jsx */
 
 import { css, jsx } from '@emotion/react'
+import { PAGE_PREFIX } from 'constants/PageConsts'
 import CategoryStrings from 'datastructures/category/CategoryStrings'
 import { Link } from 'gatsby'
 import { FC } from 'react'
@@ -25,13 +26,13 @@ const ArticleBoxCategoryLink: FC<ArticleCategoryLinkProps> = ({
 
   return (
     <div css={style}>
-      <Link to="/posts">total</Link>
+      <Link to={PAGE_PREFIX.CATEGORY}>total</Link>
       {categoriesWithCategoryLinks.map(categoryWithCategoryLink => {
         const [category, categoryLink] = categoryWithCategoryLink
         return (
           <text>
             {' > '}
-            <Link to={`/posts${categoryLink}`}>{category}</Link>
+            <Link to={categoryLink}>{category}</Link>
           </text>
         )
       })}

--- a/src/components/Categories/cells/CategoriesCategoryLink.tsx
+++ b/src/components/Categories/cells/CategoriesCategoryLink.tsx
@@ -1,0 +1,32 @@
+/** @jsx jsx */
+
+import { Link } from 'gatsby'
+import { FC } from 'react'
+import { css, jsx } from '@emotion/react'
+
+import { PAGE_PREFIX } from 'constants/PageConsts'
+import { CategoryTreeObject } from 'datastructures/category/CategoryTree'
+
+type CategoriesCategoryLinkProps = {
+  category: CategoryTreeObject
+}
+
+const style = (activated: boolean) => css`
+  font-weight: ${activated ? 'bold' : 'normal'};
+  background-color: ${activated ? 'red' : null};
+`
+
+const CategoriesCategoryLink: FC<CategoriesCategoryLinkProps> = ({
+  category,
+}) => {
+  return (
+    <Link
+      css={style(category.activated)}
+      to={PAGE_PREFIX.CATEGORY + category.slug}
+    >
+      {category.name}: {category.count}
+    </Link>
+  )
+}
+
+export default CategoriesCategoryLink

--- a/src/components/Categories/cells/CategoryCell.tsx
+++ b/src/components/Categories/cells/CategoryCell.tsx
@@ -1,9 +1,10 @@
 /** @jsx jsx */
 
 import { jsx, css } from '@emotion/react'
-import { Link } from 'gatsby'
-import { CategoryTreeObject } from 'datastructures/category/CategoryTree'
 import { FC } from 'react'
+
+import { CategoryTreeObject } from 'datastructures/category/CategoryTree'
+import CategoriesCategoryLink from './CategoriesCategoryLink'
 
 type CategoryCellProps = {
   depth?: number
@@ -17,16 +18,12 @@ const style = (depth: number) =>
 
 const CategoryCell: FC<CategoryCellProps> = ({ depth = 0, category }) => {
   return (
-    <Link to={'/posts' + category.slug}>
-      <div css={style(depth)}>
-        <div>
-          {category.name}: {category.count}
-        </div>
-        {category.sub.map(cat => {
-          return <CategoryCell depth={depth + 1} category={cat} />
-        })}
-      </div>
-    </Link>
+    <div css={style(depth)}>
+      <CategoriesCategoryLink category={category} />
+      {category.sub.map(cat => {
+        return <CategoryCell depth={depth + 1} category={cat} />
+      })}
+    </div>
   )
 }
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -9,7 +9,6 @@ import Nav from 'components/Nav'
 import LeftStack from 'components/LeftStack'
 import RightStack from 'components/RightStack'
 import { ChildrenProps } from 'types/react-types'
-import CategoryContextProvider from 'contexts/category/CategoryContextProvider'
 
 type LayoutProps = {
   leftStack?: JSX.Element
@@ -39,17 +38,15 @@ const style = css`
 
 const Layout: FC<LayoutProps> = ({ children, leftStack, rightStack }) => {
   return (
-    <CategoryContextProvider>
-      <LayoutWrapper>
-        <Nav />
-        <HStack>
-          <LeftStack stack={leftStack} />
-          <div css={style}>{children}</div>
-          <RightStack stack={rightStack} />
-        </HStack>
-        <Footer />
-      </LayoutWrapper>
-    </CategoryContextProvider>
+    <LayoutWrapper>
+      <Nav />
+      <HStack>
+        <LeftStack stack={leftStack} />
+        <div css={style}>{children}</div>
+        <RightStack stack={rightStack} />
+      </HStack>
+      <Footer />
+    </LayoutWrapper>
   )
 }
 

--- a/src/constants/PageConsts.ts
+++ b/src/constants/PageConsts.ts
@@ -1,2 +1,10 @@
 export const INDEX_PAGE_TITLE = '인덱스 페이지 입니다.'
 export const INDEX_PAGE_DESCRIPTION = '인덱스 페이지 설명입니다.'
+
+export type Pages = 'CATEGORY' | 'ARTICLE' | 'INDEX'
+
+export const PAGE_PREFIX: Record<Pages, Readonly<string>> = {
+  CATEGORY: '/categories',
+  ARTICLE: '/posts',
+  INDEX: '/',
+}

--- a/src/contexts/ArticlePageContext.tsx
+++ b/src/contexts/ArticlePageContext.tsx
@@ -1,0 +1,26 @@
+import React, { FC } from 'react'
+
+import ArticleContextProvider, {
+  ArticleContextProviderProps,
+} from './article/ArticleContextProvider'
+import CategoryContextProvider, {
+  CategoryContextProviderProps,
+} from './category/CategoryContextProvider'
+
+type ArticlePageContextProps = {} & CategoryContextProviderProps &
+  ArticleContextProviderProps
+
+const ArticlePageContext: FC<ArticlePageContextProps> = ({
+  data,
+  children,
+}) => {
+  return (
+    <>
+      <CategoryContextProvider>
+        <ArticleContextProvider data={data}>{children}</ArticleContextProvider>
+      </CategoryContextProvider>
+    </>
+  )
+}
+
+export default ArticlePageContext

--- a/src/contexts/CategoryPageContext.tsx
+++ b/src/contexts/CategoryPageContext.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react'
+
+import CategoryContextProvider, {
+  CategoryContextProviderProps,
+} from './category/CategoryContextProvider'
+
+type CategoryPageContextProps = {} & CategoryContextProviderProps
+
+const CategoryPageContext: FC<CategoryPageContextProps> = ({ children }) => {
+  return (
+    <>
+      <CategoryContextProvider>{children}</CategoryContextProvider>
+    </>
+  )
+}
+
+export default CategoryPageContext

--- a/src/contexts/article/ArticleContextProvider.tsx
+++ b/src/contexts/article/ArticleContextProvider.tsx
@@ -15,7 +15,7 @@ type ArticlePageQueryType = {
   }
 }
 
-type ArticleContextProviderProps = {
+export type ArticleContextProviderProps = {
   data: ArticlePageQueryType
 } & ChildrenProps
 

--- a/src/contexts/category/CategoryContextProvider.tsx
+++ b/src/contexts/category/CategoryContextProvider.tsx
@@ -1,24 +1,24 @@
-import React, { FC, useState } from 'react'
+import React, { FC } from 'react'
 
 import DataLayer from 'datalayer/DataLayer'
-import { CategoryTree } from 'datastructures/category/CategoryTree'
 import { ChildrenProps } from 'types/react-types'
+import activateCurrentCategories from 'utils/pageApi/activateCurrentCatgeories'
 
 import { CategoryContext } from './CategoryContext'
 
-type CategoryContextProviderProps = {} & ChildrenProps
+export type CategoryContextProviderProps = {} & ChildrenProps
 
 const CategoryContextProvider: FC<CategoryContextProviderProps> = ({
   children,
 }) => {
   const API = DataLayer.singleton().API
   const categoryTree = API.getCategoryTreeSync()
-  const [tree, mutateTree] = useState<CategoryTree>(categoryTree)
+  activateCurrentCategories(categoryTree)
 
   return (
     <CategoryContext.Provider
       value={{
-        categoryTree: tree,
+        categoryTree,
       }}
     >
       {children}

--- a/src/datastructures/category/CategoryTree.ts
+++ b/src/datastructures/category/CategoryTree.ts
@@ -5,13 +5,14 @@ export type CategoryTreeObject = {
   name: string
   count: number
   categoryDirectory: string
+  activated: boolean
   slug: string
   sub: CategoryTreeObject[]
 }
 
 export class CategoryTree {
   private static readonly ROOT_NODE_NAME = 'total'
-  root: CategoryNode
+  private root: CategoryNode
 
   constructor() {
     this.root = new CategoryNode(CategoryTree.ROOT_NODE_NAME)
@@ -19,6 +20,10 @@ export class CategoryTree {
 
   append(categories: string[], count: number) {
     this.root.add(categories, count)
+  }
+
+  activateCurrentCategory(currentSlug: string) {
+    this.root.activateRecursively(currentSlug)
   }
 
   toObject() {
@@ -29,6 +34,7 @@ export class CategoryTree {
 class CategoryNode {
   private static readonly MAX_DEPTH = CATEGORY_THRESHOLD
   private count: number = 0
+  private activated: boolean = false
   readonly subCategories: Map<string, CategoryNode> = new Map()
   readonly categoryString: CategoryStrings
 
@@ -50,6 +56,13 @@ class CategoryNode {
     this.addSubNodeRecursively(categories, count)
   }
 
+  activateRecursively(currentSlug: string) {
+    if (currentSlug.startsWith(this.categoryString.slug)) {
+      this._activate()
+    }
+    this.subCategories.forEach(cat => cat.activateRecursively(currentSlug))
+  }
+
   toObject() {
     const current: CategoryTreeObject = this.createCurrentObject()
     this.subCategories.forEach(category => {
@@ -60,11 +73,18 @@ class CategoryNode {
     return current
   }
 
+  private _activate() {
+    if (this.parent) {
+      this.activated = true
+    }
+  }
+
   private createCurrentObject() {
     return {
       name: this.name,
       count: this.count,
       slug: this.categoryString.slug,
+      activated: this.activated,
       categoryDirectory: this.categoryString.categoryDirectory,
       sub: [],
     }

--- a/src/hooks/createArticlePages.ts
+++ b/src/hooks/createArticlePages.ts
@@ -1,7 +1,9 @@
+import { resolve } from 'path'
+
 import { AllMdxQuery } from '../@types/mdx-types'
 import { PageGraphQL } from '../@types/nodeapi-types'
 import { CreatePagesArgs } from './createCategoryPages'
-import { resolve } from 'path'
+import { PAGE_PREFIX } from '../constants/PageConsts'
 
 export const createArticlePages = async (args: CreatePagesArgs) => {
   const {
@@ -13,7 +15,7 @@ export const createArticlePages = async (args: CreatePagesArgs) => {
   const results = await getAllMdx(graphql)
   results.forEach(node => {
     createPage({
-      path: 'posts' + node.fields.slug,
+      path: PAGE_PREFIX.ARTICLE + node.fields.slug,
       component: `${postTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
       context: {
         id: node.id,

--- a/src/hooks/createCategoryPages.ts
+++ b/src/hooks/createCategoryPages.ts
@@ -4,6 +4,7 @@ import { Actions } from 'gatsby'
 import { CreatePage, PageGraphQL } from '../@types/nodeapi-types'
 import { CategoryTreeObject } from '../datastructures/category/CategoryTree'
 import { CategoryPageContext } from '../templates/CategoryPage'
+import { PAGE_PREFIX } from '../constants/PageConsts'
 import DataLayer from '../dataLayer/DataLayer'
 
 export type CreatePagesArgs = {
@@ -30,7 +31,7 @@ const createPageRecur = (
     categoryDirectory: category.categoryDirectory,
   }
   createPage({
-    path: 'posts' + category.slug,
+    path: PAGE_PREFIX.CATEGORY + category.slug,
     component: resolve('./src/templates/CategoryPage.tsx'),
     context,
   })

--- a/src/templates/ArticlePage.tsx
+++ b/src/templates/ArticlePage.tsx
@@ -3,12 +3,12 @@ import { graphql } from 'gatsby'
 
 import ArticleLayout from 'components/Layout/ArticleLayout'
 import MarkdownWrapper from 'components/MarkdownWrapper'
-import ArticleContextProvider from 'contexts/article/ArticleContextProvider'
+import ArticlePageContext from 'contexts/ArticlePageContext'
 
 // @ts-ignore
 const ArticlePage = ({ data, children }) => {
   return (
-    <ArticleContextProvider data={data}>
+    <ArticlePageContext data={data}>
       <ArticleLayout>
         <div>
           <h1>{data.mdx.frontmatter.title}</h1>
@@ -16,7 +16,7 @@ const ArticlePage = ({ data, children }) => {
           <MarkdownWrapper>{children}</MarkdownWrapper>
         </div>
       </ArticleLayout>
-    </ArticleContextProvider>
+    </ArticlePageContext>
   )
 }
 

--- a/src/templates/CategoryPage.tsx
+++ b/src/templates/CategoryPage.tsx
@@ -6,6 +6,7 @@ import { AllMdxQuery } from 'types/mdx-types'
 import CategoryLayout from 'components/Layout/CategoryLayout'
 import filterArticleByCategories from 'utils/pageApi/filterArticleByCategories'
 import CategoryStrings from 'datastructures/category/CategoryStrings'
+import CategoryPageContext from 'contexts/CategoryPageContext'
 
 export type CategoryPageContext = {
   categoryDirectory: string
@@ -19,11 +20,13 @@ const CategoryPage: FC<PageProps<AllMdxQuery, CategoryPageContext>> = ({
   const articles = filterArticleByCategories(data.allMdx.nodes, categoryString)
 
   return (
-    <CategoryLayout>
-      {articles.map(article => {
-        return <ArticleBox {...article} />
-      })}
-    </CategoryLayout>
+    <CategoryPageContext>
+      <CategoryLayout>
+        {articles.map(article => {
+          return <ArticleBox {...article} />
+        })}
+      </CategoryLayout>
+    </CategoryPageContext>
   )
 }
 

--- a/src/utils/getCategoriesWithCategoryLinks.ts
+++ b/src/utils/getCategoriesWithCategoryLinks.ts
@@ -1,3 +1,4 @@
+import { PAGE_PREFIX } from 'constants/PageConsts'
 import CategoryStrings from 'datastructures/category/CategoryStrings'
 import { slugify } from './slug'
 
@@ -26,5 +27,5 @@ function copySlicedListofCategory(categories: string[], end: number) {
 function createCategoryLink(categories: string[]) {
   return categories.reduce((prev, curr) => {
     return prev + '/' + slugify(curr)
-  }, '')
+  }, PAGE_PREFIX.CATEGORY)
 }

--- a/src/utils/pageApi/activateCurrentCatgeories.ts
+++ b/src/utils/pageApi/activateCurrentCatgeories.ts
@@ -1,0 +1,39 @@
+import { Pages, PAGE_PREFIX } from 'constants/PageConsts'
+import { CategoryTree } from 'datastructures/category/CategoryTree'
+
+export default function activateCurrentCategories(tree: CategoryTree) {
+  const currentEndpoint = getCurrentEndpointDecoded()
+  const page = findCurrentPageByEndpoint(currentEndpoint)
+  const currentSlug = getCurrentSlug(currentEndpoint, page)
+
+  switch (page) {
+    case 'INDEX':
+      break
+    default:
+      tree.activateCurrentCategory(currentSlug)
+  }
+}
+
+function getCurrentEndpointDecoded() {
+  return decodeURIComponent(window.location.pathname)
+}
+
+function getCurrentSlug(currentEndpoint: string, page: Pages) {
+  const pagePrefix = PAGE_PREFIX[page]
+  return currentEndpoint.split(pagePrefix)[1]
+}
+
+function findCurrentPageByEndpoint(currentEndpoint: string) {
+  const pageKeys = Object.keys(PAGE_PREFIX) as Pages[]
+  const originPage = pageKeys.find(key =>
+    currentEndpoint.startsWith(PAGE_PREFIX[key]),
+  )
+  throwIfPageNotFound(originPage)
+  return originPage!
+}
+
+function throwIfPageNotFound(page?: Pages) {
+  if (!page) {
+    throw new Error('CategoryContext가 올바르지 않은 페이지에서 생성됨')
+  }
+}


### PR DESCRIPTION
# 작업 개요

<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->

Context API 적용 지점을 변경하고, 카테고리 사이드 바가 페이지 별로 올바르게 활성화될 수 있도록 변경합니다. 


# 이슈 티켓

<!-- ex) 작업한 이슈를 태그하세요. -->
- #21 

# 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정

# 작업 상세 내용

<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

## Context 서빙하는 지점 변경 (eb108a6839a9c3832e21fa2043e52078919c9456)
(As Is)
- 각 Context마다 필요한 Layout에 입히거나 (Category)
- Page component에 바로 적용했었음 (Article)

(To Be)
- 각 페이지를 위한 PageContext 컴포넌트를 만들고, 이 안에서부터 해당 페이지가 이용할 context를 서빙한다.
- 그리고 해당 PageContext를 Page component에서 이용함.

## 각 page별 prefix를 결정하는 상수 객체 생성
- PageConsts.PAGE_PREFIX 에서 prefix 값 결정함.
- 이외의 곳에서 prefix가 필요할 경우 해당 변수를 import해서 이용하도록 변경

## Category Context 및 CategoryTree 변경 (17513da3a281085304fe6de273c4bd339235018f)
- Category Context는 이제 useState로 tree의 상태를 관리하지 않음.
  - tree는 유저 리액션으로 내부 상태가 변경될 일이 없기 떄문
- 대신 Context를 생성할 때 tree의 내부 상태를 초기화해서 내부 컴포넌트들에게 서빙한다.
  - 현재 페이지가 속한 카테고리 노드들을 활성화함.

## 현재 페이지가 속한 카테고리 표시 (d851a7b7b061b1bbaef1c37d946abab5e9c4553b)
- activated 된 노드는 일단 빨간색으로 표시함 (추후 변경)
- 카테고리 선택 바운더리를 좁혔음 (기존에는 block 부분이 다 클릭 가능한 바운더리였다.)


# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
