### PR TITLE
[Feat] TOC 개선 및 time to read 설정

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -10,4 +10,12 @@ import 'prismjs/themes/prism-tomorrow.css'
 import './src/styles/global.css'
 
 import '@fontsource/noto-sans'
+
+import '@fontsource/noto-sans-kr'
+import '@fontsource/noto-sans-kr/100.css'
+import '@fontsource/noto-sans-kr/300.css' // Lighter
+import '@fontsource/noto-sans-kr/400.css' // Normal
+import '@fontsource/noto-sans-kr/500.css'
+import '@fontsource/noto-sans-kr/700.css' // Bold
+
 import '@fontsource/nanum-gothic'

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "gatsby-transformer-sharp": "^5.3.1",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "reading-time": "^1.5.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.4.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@emotion/styled": "^11.10.5",
     "@fontsource/nanum-gothic": "^4.5.7",
     "@fontsource/noto-sans": "^4.5.11",
+    "@fontsource/noto-sans-kr": "^4.5.12",
     "@mdx-js/react": "^2.2.1",
     "@mui/icons-material": "^5.11.0",
     "@mui/material": "^5.11.5",

--- a/src/@types/mdx-types.d.ts
+++ b/src/@types/mdx-types.d.ts
@@ -18,6 +18,7 @@ export type GroupByNode = {
 }
 
 export type MdxNode = Node & {
+  body: string
   fields: MdxField
   frontmatter: MdxFrontmatter
   excerpt: string

--- a/src/components/RightStack/TableOfContents/cells/TOCTitle.tsx
+++ b/src/components/RightStack/TableOfContents/cells/TOCTitle.tsx
@@ -5,26 +5,38 @@ import { Link } from 'gatsby'
 import { FC, useContext } from 'react'
 
 import { ArticleContext } from 'contexts/article/ArticleContext'
+import { LIGHT_GRAY } from 'styles/Color'
 
 type TOCTitleProps = {
   title?: string
   url?: string
+  activated?: boolean
 }
 
-const style = css`
+const style = (activated?: boolean) => css`
+  position: relative;
+  /* padding-block: 1px; */
+  font-size: 0.9rem;
+  font-weight: 300;
+  left: ${activated ? '-5px' : '0'};
+  transform: ${activated ? 'scale(107%)' : 'scale(100%)'};
+  color: ${activated ? 'black' : LIGHT_GRAY};
+
   :hover {
     color: black;
   }
+
+  transition: color 0.2s ease, left 0.2s ease, transform 0.2s ease;
 `
-const TOCTitle: FC<TOCTitleProps> = ({ title, url }) => {
+const TOCTitle: FC<TOCTitleProps> = ({ title, url, activated }) => {
   const {
     fields: { slug },
   } = useContext(ArticleContext)
 
   return (
-    <Link css={style} to={`/posts` + slug + url}>
-      {title}
-    </Link>
+    <div css={style(activated)}>
+      <Link to={`/posts` + slug + url}>{title}</Link>
+    </div>
   )
 }
 

--- a/src/components/RightStack/TableOfContents/cells/TableOfContentsCell.tsx
+++ b/src/components/RightStack/TableOfContents/cells/TableOfContentsCell.tsx
@@ -3,7 +3,6 @@
 import { css, jsx } from '@emotion/react'
 import { FC } from 'react'
 
-import { LIGHT_GRAY } from 'styles/Color'
 import TableNode from 'datastructures/tableOfContents/TableNode'
 import TOCTitle from './TOCTitle'
 
@@ -12,12 +11,9 @@ type TableOfContentsCellProps = {
   depth?: number
 }
 
-const style = (depth: number, activated: boolean) =>
+const style = (depth: number) =>
   css`
     margin-left: ${depth * 5}px;
-    color: ${activated ? 'black' : LIGHT_GRAY};
-    font-size: ${activated ? '1.1rem' : '1rem'};
-    transition: color 0.2s ease, font-size 0.2s ease;
   `
 
 const TableOfContentsCell: FC<TableOfContentsCellProps> = ({
@@ -25,7 +21,7 @@ const TableOfContentsCell: FC<TableOfContentsCellProps> = ({
   depth = 0,
 }) => {
   return (
-    <div css={style(data.depth, data.isActivated())}>
+    <div css={style(data.depth)}>
       <TOCTitle {...data} />
       {data.items
         ? data.items.map(item => (

--- a/src/components/RightStack/TableOfContents/index.tsx
+++ b/src/components/RightStack/TableOfContents/index.tsx
@@ -7,6 +7,7 @@ import { ArticleContext } from 'contexts/article/ArticleContext'
 import useTableOfContentsObserver from 'hooks/useTableOfContentsObserver'
 
 import TableOfContentsCell from './cells/TableOfContentsCell'
+import { BORDER_MUSK } from 'styles/Color'
 
 type TableOfContentsProps = {}
 
@@ -17,6 +18,10 @@ const style = css`
   top: 5rem;
   max-height: calc(100vh - 5rem);
   overflow: auto;
+
+  border-left: 1px solid ${BORDER_MUSK};
+  padding-block: 0.5rem;
+  padding-left: 1rem;
 `
 const TableOfContents: FC<TableOfContentsProps> = () => {
   useTableOfContentsObserver()

--- a/src/nodeApi/appendNodeField/appendCategoryDirectoryField.ts
+++ b/src/nodeApi/appendNodeField/appendCategoryDirectoryField.ts
@@ -1,0 +1,14 @@
+import { MdxNode } from '../../@types/mdx-types'
+import { CreateNodeField } from '../../@types/nodeapi-types'
+import { appendNodeField } from '../../utils/nodeApi/appendNode'
+
+export default function appendCategoryDirectoryField(
+  createNodeField: CreateNodeField,
+  node: MdxNode,
+  categoryDirectory: string,
+) {
+  appendNodeField(createNodeField, node, {
+    key: 'categoryDirectory',
+    value: categoryDirectory,
+  })
+}

--- a/src/nodeApi/appendNodeField/appendSlugField.ts
+++ b/src/nodeApi/appendNodeField/appendSlugField.ts
@@ -1,0 +1,14 @@
+import { MdxNode } from '../../@types/mdx-types'
+import { CreateNodeField } from '../../@types/nodeapi-types'
+import { appendNodeField } from '../../utils/nodeApi/appendNode'
+
+export default function appendSlugField(
+  createNodeField: CreateNodeField,
+  node: MdxNode,
+  slug: string,
+) {
+  appendNodeField(createNodeField, node, {
+    key: 'slug',
+    value: slug,
+  })
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,7 +3,7 @@ html {
 }
 
 body {
-  font-family: 'Noto Sans', sans-serif;
+  font-family: 'Noto Sans KR', sans-serif;
   margin: 0;
   display: flex;
   justify-content: center;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,6 +1239,11 @@
   resolved "https://registry.npmjs.org/@fontsource/nanum-gothic/-/nanum-gothic-4.5.7.tgz#686e7cae0d2f26bf41442610012a89c01a2bb00b"
   integrity sha512-vH3GQpsyNWPkUSnQasIjWAHEUP77mlQ4UH/ozXvgimQNvzO2SiTw5wiG/mxqRd8cNNZnFrSwHDU3GI3b4IgtnA==
 
+"@fontsource/noto-sans-kr@^4.5.12":
+  version "4.5.12"
+  resolved "https://registry.npmjs.org/@fontsource/noto-sans-kr/-/noto-sans-kr-4.5.12.tgz#382d6cdd1928943ca15e80ca013e3b6cf5809f50"
+  integrity sha512-6LBOzXw/V4guB/nATaiUjCcPxwJNGw+ky5DK7/wsgUZvfk8etH9IlKdvjFVidpeCuMVjOdlka2+MEw4hwEHaHA==
+
 "@fontsource/noto-sans@^4.5.11":
   version "4.5.11"
   resolved "https://registry.npmjs.org/@fontsource/noto-sans/-/noto-sans-4.5.11.tgz#9074486d876577f3688f884c7ad6196d6dbea27e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10534,6 +10534,11 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+reading-time@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz#d2a7f1b6057cb2e169beaf87113cc3411b5bc5bb"
+  integrity sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==
+
 recursive-readdir@^2.2.2:
   version "2.2.3"
   resolved "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz"


### PR DESCRIPTION
# 작업 개요

<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->

# 이슈 티켓
- #22 

<!-- ex) 작업한 이슈를 태그하세요. -->

# 작업 분류
- [ ] 버그 수정
- [o] 신규 기능
- [o] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정

# 작업 상세 내용

<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

## Noto Sans KR 의존성 다운로드 및 폰트 적용 (004016573a724f66c01d0c03cf731dd142750be4)
- 기존의 @fontsource/noto-sans의 경우 한글 폰트에 font-weight가 정상적으로 적용되지 않았음.
- normal의 400이나 bold인 700에는 영한 모두 일괄적으로 적용되었지만 기타 300 혹은 600의 font-weight의 경우 한글 폰트는 속성 적용이 씹히는 현상이 나타남.
- 한글을 위한 Noto Sans KR 폰트가 fontsource에 있더라고. 이거 다운로드 받고,
- browser에 가능한 font-weight들을 모두 import 해줌.
- 또한 global font-family를 Noto Sans KR로 적용.

## TOC activate 시 이펙트 변경 (428739221aa1f7a77e6abb95d1778e70df6c3b9e)
(As Is)
TableOfContentsCell 자체에서 activate 시 이펙트를 적용했음.
- 기존에는 font-size 정도만 적용했었다.
- 어차피 재귀적으로 하위노드로 뻗어가더라도 font-size는 재설정되니까 문제가 없었음.
- 그치만 margin 속성이나 left 속성은 상위노드에 영향을 받다보니 그 값들이 중첩되어 적용되게됨.

(To Be)
TOCTitle 에서 이펙트를 적용한다.

---
- 기존에는 font-size만 변경해주었음.
- 이러면 width는 동일한 상태에서 font-size가 커져 매 activate 시마다 line break가 일어났다 다시 없어져 보기 안좋았음.
- activate 시 scale을 변경하는 방식으로 변경.
- 또한 position을 relative로 잡고  activate 시 left로 element 위치를 조정해준다.
- TOC 전체의 왼쪽에 구분선도 만들어줌!

## reading time 의존성 설치 (c4223da4f102430a5b4e15474f90a8b4f9d0760c)
- time to read 계산하기 위해서.

## type narrowing, node-api를 위한 함수 디렉토리 생성  (3d95d091b3f21074ff595d685c16847c9cea187d)
- /src/nodeApi/ 에 함수들 집어넣음.
- onMdxAppendFields.ts 함수의 MdxNode로 타입 좁히는 과정을 앞에서 해줌.

# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
