### PR TITLE
[Feat] ArticlePage에 Min Reads 표기

### DIFF
--- a/src/@types/mdx-types.d.ts
+++ b/src/@types/mdx-types.d.ts
@@ -27,6 +27,7 @@ export type MdxNode = Node & {
 export type MdxField = {
   slug: string
   categoryDirectory: string
+  timeToRead: number
 }
 
 export type MdxFrontmatter = {

--- a/src/@types/mdx-types.d.ts
+++ b/src/@types/mdx-types.d.ts
@@ -19,15 +19,16 @@ export type GroupByNode = {
 
 export type MdxNode = Node & {
   body: string
+  excerpt: string
   fields: MdxField
   frontmatter: MdxFrontmatter
-  excerpt: string
+  tableOfContents: MdxTableOfContent
 }
 
 export type MdxField = {
   slug: string
-  categoryDirectory: string
   timeToRead: number
+  categoryDirectory: string
 }
 
 export type MdxFrontmatter = {

--- a/src/components/ArticleFrontmatter/ArticleFrontmatterDate.tsx
+++ b/src/components/ArticleFrontmatter/ArticleFrontmatterDate.tsx
@@ -1,0 +1,36 @@
+/** @jsx jsx */
+
+import { FC } from 'react'
+import { jsx, css } from '@emotion/react'
+import { GRAY } from 'styles/Color'
+
+type ArticleFrontmatterDateProps = {
+  createdAt: string
+  timeToRead: number
+  modifiedAt?: string
+}
+
+const style = css`
+  padding-left: 0.4rem;
+`
+
+const creationCSS = css`
+  font-size: 0.9rem;
+  color: ${GRAY};
+`
+
+const ArticleFrontmatterDate: FC<ArticleFrontmatterDateProps> = ({
+  createdAt,
+  timeToRead,
+  modifiedAt,
+}) => {
+  return (
+    <div css={style}>
+      <span css={creationCSS}>
+        {createdAt} · ☕️ {timeToRead} min reads
+      </span>
+    </div>
+  )
+}
+
+export default ArticleFrontmatterDate

--- a/src/components/ArticleFrontmatter/ArticleFrontmatterTitle.tsx
+++ b/src/components/ArticleFrontmatter/ArticleFrontmatterTitle.tsx
@@ -1,0 +1,29 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import { FC } from 'react'
+
+import { m_mq } from 'styles/facepaint'
+import Mapper from 'utils/Mapper'
+
+type ArticleFrontmatterTitleProps = {
+  title: string
+}
+
+const style = css(
+  css`
+    margin-block: 0.5rem;
+    font-weight: 500;
+  `,
+  m_mq({
+    fontSize: Mapper.mapRem([2, 2.8]),
+  }),
+)
+
+const ArticleFrontmatterTitle: FC<ArticleFrontmatterTitleProps> = ({
+  title,
+}) => {
+  return <h1 css={style}>{title}</h1>
+}
+
+export default ArticleFrontmatterTitle

--- a/src/components/ArticleFrontmatter/index.tsx
+++ b/src/components/ArticleFrontmatter/index.tsx
@@ -1,0 +1,39 @@
+/** @jsx jsx */
+
+import { css, jsx } from '@emotion/react'
+import { FC } from 'react'
+
+import ArticleFrontmatterDate from './ArticleFrontmatterDate'
+import ArticleFrontmatterTitle from './ArticleFrontmatterTitle'
+
+type ArticleFrontmatterProps = {
+  title: string
+  createdAt: string
+  modifiedAt?: string
+  timeToRead: number
+}
+
+const style = css`
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+`
+
+const ArticleFrontmatter: FC<ArticleFrontmatterProps> = ({
+  title,
+  createdAt,
+  modifiedAt,
+  timeToRead,
+}) => {
+  return (
+    <div css={style}>
+      <ArticleFrontmatterTitle title={title} />
+      <ArticleFrontmatterDate
+        createdAt={createdAt}
+        modifiedAt={modifiedAt}
+        timeToRead={timeToRead}
+      />
+    </div>
+  )
+}
+
+export default ArticleFrontmatter

--- a/src/contexts/article/ArticleContextProvider.tsx
+++ b/src/contexts/article/ArticleContextProvider.tsx
@@ -1,22 +1,15 @@
 import { FC, useState } from 'react'
 
-import { MdxField, MdxFrontmatter, MdxTableOfContent } from 'types/mdx-types'
+import { MdxNode } from 'types/mdx-types'
 import { ChildrenProps } from 'types/react-types'
 import TableOfContentTree from 'datastructures/tableOfContents/TableOfContentTree'
 
 import { ArticleContext } from './ArticleContext'
 
-type ArticlePageQueryType = {
-  mdx: {
-    id: string
-    fields: MdxField
-    frontmatter: MdxFrontmatter
-    tableOfContents: MdxTableOfContent
-  }
-}
-
 export type ArticleContextProviderProps = {
-  data: ArticlePageQueryType
+  data: {
+    mdx: MdxNode
+  }
 } & ChildrenProps
 
 const ArticleContextProvider: FC<ArticleContextProviderProps> = ({

--- a/src/nodeApi/appendNodeField/appendTimeToReadField.ts
+++ b/src/nodeApi/appendNodeField/appendTimeToReadField.ts
@@ -1,0 +1,20 @@
+import readingTime from 'reading-time'
+
+import { MdxNode } from '../../@types/mdx-types'
+import { CreateNodeField } from '../../@types/nodeapi-types'
+import { appendNodeField } from '../../utils/nodeApi/appendNode'
+
+export default function appendTimeToRead(
+  createNodeField: CreateNodeField,
+  node: MdxNode,
+) {
+  appendNodeField(createNodeField, node, {
+    key: 'timeToRead',
+    value: getReadingTime(node.body),
+  })
+}
+
+function getReadingTime(body: string) {
+  const { minutes } = readingTime(body)
+  return Math.round(minutes)
+}

--- a/src/templates/ArticlePage.tsx
+++ b/src/templates/ArticlePage.tsx
@@ -3,18 +3,21 @@ import { graphql } from 'gatsby'
 
 import ArticleLayout from 'components/Layout/ArticleLayout'
 import MarkdownWrapper from 'components/MarkdownWrapper'
+import ArticleFrontmatter from 'components/ArticleFrontmatter'
 import ArticlePageContext from 'contexts/ArticlePageContext'
 
 // @ts-ignore
 const ArticlePage = ({ data, children }) => {
+  const frontmatters = {
+    ...data.mdx.frontmatter,
+    timeToRead: data.mdx.fields.timeToRead,
+  }
+
   return (
     <ArticlePageContext data={data}>
       <ArticleLayout>
-        <div>
-          <h1>{data.mdx.frontmatter.title}</h1>
-          <div>Post Date: {data.mdx.frontmatter.createdAt}</div>
-          <MarkdownWrapper>{children}</MarkdownWrapper>
-        </div>
+        <ArticleFrontmatter {...frontmatters} />
+        <MarkdownWrapper>{children}</MarkdownWrapper>
       </ArticleLayout>
     </ArticlePageContext>
   )
@@ -30,9 +33,10 @@ export const query = graphql`
       excerpt
       fields {
         slug
+        timeToRead
       }
       frontmatter {
-        createdAt(formatString: "MMM DD, YYYY")
+        createdAt(formatString: "MMMM DD, YYYY")
         slug
         tags
         title

--- a/src/templates/ArticlePage.tsx
+++ b/src/templates/ArticlePage.tsx
@@ -29,8 +29,6 @@ export const query = graphql`
   query ($id: String) {
     mdx(id: { eq: $id }) {
       id
-      body
-      excerpt
       fields {
         slug
         timeToRead


### PR DESCRIPTION
# 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
Article Page에 Min Read time 추가 

# 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->

- #22 

# 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정

# 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

## Article Page frontmatter 및 timetoread 설정 (483dcde70c381ae6af9ddbfa33c7c245db24f89d)
- createNode 시 mdx node에 대해서 timeToRead 필드 추가

## 타이핑 정리, 안쓰이는 page query 필드 삭제 (20bf37613748a2c0d4f605cfc4e69d4f7cb1fb8d)


# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
