### PR TITLE
[Feat] recent posts 컴포넌트 추가 + MUI 적용

### DIFF
--- a/src/components/Layout/ArticleLayout.tsx
+++ b/src/components/Layout/ArticleLayout.tsx
@@ -5,6 +5,7 @@ import { ChildrenProps } from 'types/react-types'
 
 import Layout from '.'
 import BioAndCategories from 'components/LeftStack/BioAndCategories'
+import { Container } from '@mui/material'
 
 type ArticleLayoutProps = {} & ChildrenProps
 
@@ -14,7 +15,11 @@ const layoutProps = {
 }
 
 const ArticleLayout: FC<ArticleLayoutProps> = ({ children }) => {
-  return <Layout {...layoutProps}>{children}</Layout>
+  return (
+    <Layout {...layoutProps}>
+      <Container>{children}</Container>
+    </Layout>
+  )
 }
 
 export default ArticleLayout

--- a/src/components/Layout/CategoryLayout.tsx
+++ b/src/components/Layout/CategoryLayout.tsx
@@ -2,6 +2,7 @@ import BioAndCategories from 'components/LeftStack/BioAndCategories'
 import React, { FC } from 'react'
 import { ChildrenProps } from 'types/react-types'
 import Layout from '.'
+import { Container } from '@mui/material'
 
 type CategoryLayoutProps = {} & ChildrenProps
 
@@ -10,7 +11,11 @@ const layoutProps = {
 }
 
 const CategoryLayout: FC<CategoryLayoutProps> = ({ children }) => {
-  return <Layout {...layoutProps}>{children}</Layout>
+  return (
+    <Layout {...layoutProps}>
+      <Container>{children}</Container>
+    </Layout>
+  )
 }
 
 export default CategoryLayout

--- a/src/components/RecentPosts/RecentPost.tsx
+++ b/src/components/RecentPosts/RecentPost.tsx
@@ -1,0 +1,59 @@
+/** @jsx jsx */
+
+import { FC } from 'react'
+import { jsx, css } from '@emotion/react'
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Link,
+  Typography,
+} from '@mui/material'
+import { PAGE_PREFIX } from 'constants/PageConsts'
+import { RecentPostDetails } from './RecentPosts'
+
+interface RecentPostProps {
+  prev?: boolean
+  next?: boolean
+  post?: RecentPostDetails
+}
+
+const style = css``
+
+const RecentPost: FC<RecentPostProps> = ({ prev, next, post }) => {
+  return (
+    <div css={style} hidden={!post}>
+      <Card>
+        <CardActionArea>
+          <Link
+            href={PAGE_PREFIX.ARTICLE + post?.fields.slug}
+            style={{ textDecoration: 'none' }}
+          >
+            <CardContent
+              sx={
+                next
+                  ? {
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'flex-end',
+                    }
+                  : null
+              }
+            >
+              <Typography color={'gray'} variant="body2">
+                {prev ? '이전 포스트' : '다음 포스트'}
+              </Typography>
+              <Typography variant="subtitle1">
+                {prev
+                  ? `<< ${post?.frontmatter.title}`
+                  : `${post?.frontmatter.title} >>`}
+              </Typography>
+            </CardContent>
+          </Link>
+        </CardActionArea>
+      </Card>
+    </div>
+  )
+}
+
+export default RecentPost

--- a/src/components/RecentPosts/RecentPosts.tsx
+++ b/src/components/RecentPosts/RecentPosts.tsx
@@ -1,0 +1,44 @@
+/** @jsx jsx */
+
+import { FC } from 'react'
+import { jsx, css } from '@emotion/react'
+import {
+  Card,
+  CardActionArea,
+  CardContent,
+  Grid,
+  Link,
+  Typography,
+} from '@mui/material'
+import RecentPost from './RecentPost'
+
+type RecentPostsProps = {
+  prev?: RecentPostDetails
+  next?: RecentPostDetails
+}
+
+export interface RecentPostDetails {
+  fields: {
+    slug: string
+  }
+  frontmatter: {
+    title: string
+  }
+}
+
+const style = css``
+
+const RecentPosts: FC<RecentPostsProps> = ({ prev, next }) => {
+  return (
+    <Grid marginY={5} container columnSpacing={2} rowSpacing={2}>
+      <Grid item xs={12} sm={6}>
+        <RecentPost prev post={prev} />
+      </Grid>
+      <Grid item xs={12} sm={6}>
+        <RecentPost next post={next} />
+      </Grid>
+    </Grid>
+  )
+}
+
+export default RecentPosts

--- a/src/hooks/createArticlePages.ts
+++ b/src/hooks/createArticlePages.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 
-import { AllMdxQuery } from '../@types/mdx-types'
+import { AllMdxQuery, MdxNode } from '../@types/mdx-types'
 import { PageGraphQL } from '../@types/nodeapi-types'
 import { CreatePagesArgs } from './createCategoryPages'
 import { PAGE_PREFIX } from '../constants/PageConsts'
@@ -13,14 +13,20 @@ export const createArticlePages = async (args: CreatePagesArgs) => {
 
   const postTemplate = resolve(`src/templates/ArticlePage.tsx`)
   const results = await getAllMdx(graphql)
-  results.forEach(node => {
+
+  let nextNode: MdxNode | undefined
+
+  results.forEach((node, index) => {
     createPage({
       path: PAGE_PREFIX.ARTICLE + node.fields.slug,
       component: `${postTemplate}?__contentFilePath=${node.internal.contentFilePath}`,
       context: {
         id: node.id,
+        prevId: results[index + 1]?.id,
+        nextId: nextNode?.id,
       },
     })
+    nextNode = node
   })
 }
 

--- a/src/templates/ArticlePage.tsx
+++ b/src/templates/ArticlePage.tsx
@@ -6,9 +6,11 @@ import MarkdownWrapper from 'components/MarkdownWrapper'
 import ArticleFrontmatter from 'components/ArticleFrontmatter'
 import ArticlePageContext from 'contexts/ArticlePageContext'
 import Utterances from 'components/Utterance'
+import RecentPosts from 'components/RecentPosts/RecentPosts'
 
 // @ts-ignore
 const ArticlePage = ({ data, children }) => {
+  const { prevPost, nextPost } = data
   const frontmatters = {
     ...data.mdx.frontmatter,
     timeToRead: data.mdx.fields.timeToRead,
@@ -19,6 +21,7 @@ const ArticlePage = ({ data, children }) => {
       <ArticleLayout>
         <ArticleFrontmatter {...frontmatters} />
         <MarkdownWrapper>{children}</MarkdownWrapper>
+        <RecentPosts prev={prevPost} next={nextPost} />
         <Utterances />
       </ArticleLayout>
     </ArticlePageContext>
@@ -28,7 +31,7 @@ const ArticlePage = ({ data, children }) => {
 export default ArticlePage
 
 export const query = graphql`
-  query ($id: String) {
+  query ($id: String, $nextId: String, $prevId: String) {
     mdx(id: { eq: $id }) {
       id
       fields {
@@ -41,6 +44,22 @@ export const query = graphql`
         createdAt(formatString: "MMMM DD, YYYY")
       }
       tableOfContents
+    }
+    prevPost: mdx(id: { eq: $prevId }) {
+      fields {
+        slug
+      }
+      frontmatter {
+        title
+      }
+    }
+    nextPost: mdx(id: { eq: $nextId }) {
+      fields {
+        slug
+      }
+      frontmatter {
+        title
+      }
     }
   }
 `


### PR DESCRIPTION
# 작업 개요

<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
이전, 다음 글을 보여주는 recent post 컴포넌트를 추가함
이에 필요한 data layer 및 쿼리 수정이 있었고 recentpost를 렌더할 컴포넌트를 생성함. 
약간의 MUI도 도입했다.

# 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->
- #58 

# 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정

# 작업 상세 내용
<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->

## [MUI 적용 - layout에 container](https://github.com/leobang17/gatsby-theme-simplex/commit/51f864fee01b834a766054f76e915063922a2299)

##[createPages api 변경](https://github.com/leobang17/gatsby-theme-simplex/commit/c4a9a42984ab4e48e1c59611f4c86177ab27f787)
- article page의 context에 prev, next page를 쿼리할 수 있도록  대한 정보를 건넨다.

## [ArticlePages 데이터레이어 변경분 적용 + RecentPost 컴포넌트](https://github.com/leobang17/gatsby-theme-simplex/commit/6a69e610e23035cdb78db591c08be188cf6fef40)

# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
