### PR TITLE
[Feat] emotion -> Mui로 마이그레이션 중 + tss 도입

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
       "comments": "on",
       "strings": "on",
       "other": "on"
-    }
+    },
+    "editor.formatOnSave": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "reading-time": "^1.5.0",
-    "remark-gfm": "^1"
+    "remark-gfm": "^1",
+    "tss-react": "^4.8.8"
   },
   "devDependencies": {
     "@jest/globals": "^29.4.1",

--- a/package.json
+++ b/package.json
@@ -73,5 +73,10 @@
     "prettier": "^2.8.2",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.4"
+  },
+  "resolutions": {
+    "@types/react": "17.0.2",
+    "@types/react-dom": "17.0.2",
+    "graphql": "^16.5.0"
   }
 }

--- a/src/components/ArticleBox/ArticleBoxCategoryLink.tsx
+++ b/src/components/ArticleBox/ArticleBoxCategoryLink.tsx
@@ -1,32 +1,31 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/react'
-import { themeConfigs } from '../../configuration'
+import { jsx } from '@emotion/react'
 import { PAGE_PREFIX } from 'constants/PageConsts'
 import CategoryStrings from 'datastructures/category/CategoryStrings'
 import { Link } from 'gatsby'
 import { FC } from 'react'
 import getCategoriesWithCategoryLinks from 'utils/getCategoriesWithCategoryLinks'
+import { Typography } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
 type ArticleCategoryLinkProps = {
   categoryString: CategoryStrings
 }
 
-const style = css`
-  color: ${themeConfigs.light.main};
-  padding-left: 3px;
-  font-size: 0.8rem;
-  padding-bottom: 0.2rem;
-`
+const useStyles = makeStyles()({
+  root: {},
+})
 
 const ArticleBoxCategoryLink: FC<ArticleCategoryLinkProps> = ({
   categoryString,
 }) => {
+  const { classes } = useStyles()
   const categoriesWithCategoryLinks =
     getCategoriesWithCategoryLinks(categoryString)
 
   return (
-    <div css={style}>
+    <Typography color="primary" variant="subtitle2" className={classes.root}>
       <Link to={PAGE_PREFIX.CATEGORY}>total</Link>
       {categoriesWithCategoryLinks.map((categoryWithCategoryLink, id) => {
         const [category, categoryLink] = categoryWithCategoryLink
@@ -37,7 +36,7 @@ const ArticleBoxCategoryLink: FC<ArticleCategoryLinkProps> = ({
           </span>
         )
       })}
-    </div>
+    </Typography>
   )
 }
 

--- a/src/components/ArticleBox/ArticleBoxTitle.tsx
+++ b/src/components/ArticleBox/ArticleBoxTitle.tsx
@@ -1,29 +1,38 @@
 /** @jsx jsx */
 
 import { FC } from 'react'
-import { css, jsx } from '@emotion/react'
-import styled from '@emotion/styled'
+import { jsx } from '@emotion/react'
+import { Typography } from '@mui/material'
 import { Link } from 'gatsby'
 
-import * as Semantic from 'styles/designSystem/semantic'
+import { PAGE_PREFIX } from 'constants/PageConsts'
+import { makeStyles } from 'tss-react/mui'
 
 export type ArticleBoxTitleProps = {
   slug: string
   title: string
 }
 
-const style = css`
-  display: inline-block;
-`
+const useStyles = makeStyles()(theme => ({
+  root: {
+    transition: 'all 0.1s ease',
 
-const TitleWrapper = styled(Semantic.H2)`
-  margin: 0;
-`
+    ':hover': {
+      color:
+        theme.palette.mode === 'dark'
+          ? theme.palette.primary.dark
+          : theme.palette.primary.light,
+    },
+  },
+}))
 
 const ArticleBoxTitle: FC<ArticleBoxTitleProps> = ({ slug, title }) => {
+  const { classes } = useStyles()
   return (
-    <Link css={style} to={'/posts' + slug}>
-      <TitleWrapper>{title}</TitleWrapper>
+    <Link to={PAGE_PREFIX.ARTICLE + slug}>
+      <Typography variant="h5" className={classes.root}>
+        {title}
+      </Typography>
     </Link>
   )
 }

--- a/src/components/ArticleBox/index.tsx
+++ b/src/components/ArticleBox/index.tsx
@@ -1,7 +1,6 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/react'
-import styled from '@emotion/styled'
+import { jsx } from '@emotion/react'
 import { FC } from 'react'
 
 import { MdxNode } from 'types/mdx-types'
@@ -9,36 +8,55 @@ import { GRAY } from 'styles/Color'
 import ArticleBoxTitle from './ArticleBoxTitle'
 import ArticleBoxCategoryLink from './ArticleBoxCategoryLink'
 import CategoryStrings from 'datastructures/category/CategoryStrings'
-import * as Semantic from 'styles/designSystem/semantic'
 
-const style = css`
-  margin-block: 3rem;
-`
+import { Box, Typography } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
-const spanStyle = css`
-  display: block;
-`
-
-const CreatedAt = styled.time`
-  color: ${GRAY};
-  font-size: 0.8rem;
-  margin-top: 0.5rem;
-`
+const useStyles = makeStyles()(theme => ({
+  root: {
+    marginBlock: '3rem',
+  },
+  summary: {
+    display: 'block',
+  },
+  createdAt: {
+    color:
+      theme.palette.mode === 'dark'
+        ? theme.palette.subText.contrastText
+        : theme.palette.subText.main,
+    marginTop: '0.5rem',
+  },
+}))
 
 const ArticleBox: FC<MdxNode> = ({
   fields: { slug, categoryDirectory },
   frontmatter: { title, createdAt },
   excerpt,
 }) => {
+  const { classes } = useStyles()
   return (
-    <section css={style}>
+    <Box component="section" className={classes.root}>
       <ArticleBoxCategoryLink
         categoryString={CategoryStrings.initialize(categoryDirectory)}
       />
       <ArticleBoxTitle slug={slug} title={title} />
-      <Semantic.SUMMARY css={spanStyle}>{excerpt}</Semantic.SUMMARY>
-      <CreatedAt>{createdAt}</CreatedAt>
-    </section>
+
+      <Typography
+        component="summary"
+        variant="body1"
+        className={classes.summary}
+      >
+        {excerpt}
+      </Typography>
+
+      <Typography
+        component="time"
+        variant="body2"
+        className={classes.createdAt}
+      >
+        {createdAt}
+      </Typography>
+    </Box>
   )
 }
 

--- a/src/components/CategoryTable/cells/CategoryCount.tsx
+++ b/src/components/CategoryTable/cells/CategoryCount.tsx
@@ -1,21 +1,24 @@
 /** @jsx jsx */
 
 import { FC } from 'react'
-import { jsx, css } from '@emotion/react'
+import { jsx } from '@emotion/react'
+import { Chip } from '@mui/material'
 
 type CategoryCountProps = {
   count: number
 }
 
-const style = css`
-  padding-inline: 5px;
-  margin-inline: 10px;
-  border-radius: 5px;
-  background-color: whitesmoke;
-`
-
 const CategoryCount: FC<CategoryCountProps> = ({ count }) => {
-  return <div css={style}>{count}</div>
+  return (
+    <Chip
+      label={count}
+      sx={{
+        borderRadius: '5px',
+        marginInline: '10px',
+        height: '1.5rem',
+      }}
+    />
+  )
 }
 
 export default CategoryCount

--- a/src/components/CategoryTable/cells/CategoryRow.tsx
+++ b/src/components/CategoryTable/cells/CategoryRow.tsx
@@ -1,50 +1,71 @@
 /** @jsx jsx */
 
 import { Link } from 'gatsby'
-import { FC } from 'react'
-import { css, jsx } from '@emotion/react'
+import { FC, useContext } from 'react'
+import { jsx } from '@emotion/react'
 
 import { PAGE_PREFIX } from 'constants/PageConsts'
 import { CategoryTreeObject } from 'datastructures/category/CategoryTree'
 import CategoryCount from './CategoryCount'
-import { themeConfigs } from '../../../configuration'
+
+import { Paper, Typography } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
 type CategoryRowProps = {
   category: CategoryTreeObject
 }
 
-const style = (activated: boolean) => css`
-  display: flex;
-  align-items: center;
-  padding-block: 0.3rem;
-  padding-inline: 0.5rem;
-  border-left: 2px solid ${activated ? themeConfigs.light.main : 'inherit'};
-  background-color: ${activated ? '#EEEEEE' : null};
-  font-weight: ${activated ? 400 : 300};
+const useStyles = makeStyles<{
+  activated: boolean
+  nodeDepth: number
+}>()((theme, { activated, nodeDepth }) => ({
+  categoryRow: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingBlock: '0.3rem',
+    paddingInline: '0.5rem',
+    marginBlock: '1px',
+    fontWeight: activated ? 600 : 500,
+    backgroundColor: activated
+      ? theme.palette.mode === 'dark'
+        ? theme.palette.navbar.dark
+        : theme.palette.navbar.main
+      : 'inherit',
 
-  :hover {
-    background-color: ${activated ? '#EEEEEE' : '#F4F7F7'};
-  }
-`
+    ':hover': {
+      backgroundColor:
+        theme.palette.mode === 'dark'
+          ? theme.palette.navbar.dark
+          : theme.palette.navbar.main,
+    },
+  },
 
-const linkStyle = (nodeDepth: number) => css`
-  display: flex;
-  flex: 1;
-  flex-direction: row;
-  align-items: center;
-  padding-left: ${nodeDepth * 0.5}rem;
-`
+  categoryTypo: {
+    fontWeight: activated ? 600 : 500,
+    color: activated
+      ? theme.palette.mode === 'dark'
+        ? theme.palette.primary.dark
+        : theme.palette.primary.light
+      : 'inherit',
+    paddingLeft: `${0.5 + nodeDepth * 0.5}rem`,
+  },
+}))
 
 const CategoryRow: FC<CategoryRowProps> = ({ category }) => {
+  const { classes } = useStyles({
+    activated: category.activated,
+    nodeDepth: category.nodeDepth,
+  })
+
   return (
-    <Link
-      css={style(category.activated)}
-      to={PAGE_PREFIX.CATEGORY + category.slug}
-    >
-      <div css={linkStyle(category.nodeDepth)}>
-        <div>{category.name}</div>
+    <Link to={PAGE_PREFIX.CATEGORY + category.slug}>
+      <Paper className={classes.categoryRow} elevation={0}>
+        <Typography className={classes.categoryTypo}>
+          {category.name}
+        </Typography>
         <CategoryCount count={category.count} />
-      </div>
+      </Paper>
     </Link>
   )
 }

--- a/src/components/CategoryTable/cells/RecursiveCategories.tsx
+++ b/src/components/CategoryTable/cells/RecursiveCategories.tsx
@@ -5,6 +5,7 @@ import { FC } from 'react'
 
 import { CategoryTreeObject } from 'datastructures/category/CategoryTree'
 import CategoryRow from './CategoryRow'
+import Stack from '@mui/material/Stack'
 
 type CategoryCellProps = {
   category: CategoryTreeObject
@@ -16,12 +17,12 @@ const style = css`
 
 const RecursiveCategories: FC<CategoryCellProps> = ({ category }) => {
   return (
-    <div css={style}>
+    <Stack css={style}>
       <CategoryRow category={category} />
       {category.sub.map((cat, id) => {
         return <RecursiveCategories category={cat} key={id} />
       })}
-    </div>
+    </Stack>
   )
 }
 

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,47 +1,63 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/react'
-import { themeConfigs } from '../../configuration'
+import { jsx } from '@emotion/react'
 import { FC } from 'react'
-import { BORDER_MUSK } from 'styles/Color'
 import FooterOrigin from './cells/FooterOrigin'
 import FooterUsername from './cells/FooterUsername'
+import { Box, Typography } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
 type FooterProps = {}
 
-const style = css`
-  width: 100vw;
-  margin-top: 5rem;
-  padding: 1rem 0 1rem 0;
-  border-top: 1px solid ${BORDER_MUSK};
-  font-size: small;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  color: #515055;
+const useStyles = makeStyles()(theme => ({
+  root: {
+    width: '100vw',
+    paddingBlock: '1rem',
+    marginTop: '5rem',
+    borderTop: '1px solid',
+    borderColor:
+      theme.palette.mode === 'dark'
+        ? theme.palette.border.dark
+        : theme.palette.border.main,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
 
-  a {
-    transition: color 0.15s ease;
-    :hover {
-      color: ${themeConfigs.light.main};
-    }
-  }
-`
+  text: {
+    marginBlock: '1rem',
+    color:
+      theme.palette.mode === 'dark'
+        ? theme.palette.subText.contrastText
+        : theme.palette.subText.main,
 
-const sectionStyle = css`
-  margin-block: 1rem;
-`
+    a: {
+      transition: 'color 0.15s ease',
+      ':hover': {
+        color:
+          theme.palette.mode === 'dark'
+            ? theme.palette.primary.dark
+            : theme.palette.primary.light,
+      },
+    },
+  },
+}))
 
 const Footer: FC<FooterProps> = ({}) => {
+  const { classes } = useStyles()
   return (
-    <footer css={style}>
-      <section css={sectionStyle}>
+    <Box component="footer" className={classes.root}>
+      <Typography
+        component="section"
+        variant="subtitle2"
+        className={classes.text}
+      >
         <FooterUsername />
         <span>Theme by </span>
         <FooterOrigin />
         <span>, Built with Gatsby</span>
-      </section>
-    </footer>
+      </Typography>
+    </Box>
   )
 }
 

--- a/src/components/Layout/ArticleLayout.tsx
+++ b/src/components/Layout/ArticleLayout.tsx
@@ -5,7 +5,6 @@ import { ChildrenProps } from 'types/react-types'
 
 import Layout from '.'
 import BioAndCategories from 'components/LeftStack/BioAndCategories'
-import { Container } from '@mui/material'
 
 type ArticleLayoutProps = {} & ChildrenProps
 
@@ -15,11 +14,7 @@ const layoutProps = {
 }
 
 const ArticleLayout: FC<ArticleLayoutProps> = ({ children }) => {
-  return (
-    <Layout {...layoutProps}>
-      <Container>{children}</Container>
-    </Layout>
-  )
+  return <Layout {...layoutProps}>{children}</Layout>
 }
 
 export default ArticleLayout

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -2,16 +2,17 @@
 
 import React, { FC, useContext } from 'react'
 import styled from '@emotion/styled'
-import { css, jsx } from '@emotion/react'
+import { jsx } from '@emotion/react'
 
 import Footer from 'components/Footer'
 import LeftStack from 'components/LeftStack'
 import RightStack from 'components/RightStack'
 import { ChildrenProps } from 'types/react-types'
-import { CssBaseline } from '@mui/material'
+import { Box, Container, CssBaseline } from '@mui/material'
 import MUINav from 'components/Nav/MUINav'
 import { ThemeContext } from 'contexts/theme/ThemeContext'
 import { ModeSwitch } from 'components/Nav/cells/ModeSwitch'
+import { makeStyles } from 'tss-react/mui'
 
 type LayoutProps = {
   leftStack?: JSX.Element
@@ -26,21 +27,23 @@ const LayoutWrapper = styled.html`
   align-items: center;
 `
 
-const HStack = styled.div`
-  display: flex;
-  flex: 1;
-  flex-direction: row;
-  justify-content: space-around;
-  width: 100vw;
-`
+const useStyles = makeStyles()({
+  pageWrapper: {
+    display: 'flex',
+    flexGrow: 1,
+    flexDirection: 'row',
+    width: '100vw',
+    justifyContent: 'space-around',
+  },
 
-const style = css`
-  width: 100%;
-  max-width: 770px;
-  margin-inline: 20px;
-`
+  main: {
+    maxWidth: '770px',
+    marginInline: '20px',
+  },
+})
 
 const Layout: FC<LayoutProps> = ({ children, leftStack, rightStack }) => {
+  const { classes } = useStyles()
   const { mode, switchMode } = useContext(ThemeContext)
 
   return (
@@ -48,11 +51,25 @@ const Layout: FC<LayoutProps> = ({ children, leftStack, rightStack }) => {
       <CssBaseline />
       <LayoutWrapper>
         <MUINav />
-        <HStack>
+        <Box className={classes.pageWrapper}>
           <LeftStack stack={leftStack} />
-          <main css={style}>{children}</main>
+          <Container
+            component="main"
+            maxWidth={false}
+            className={classes.main}
+            sx={{
+              width: {
+                xs: '100vw',
+                sm: '100vw',
+                md: '100vw',
+                lg: '50vw',
+              },
+            }}
+          >
+            {children}
+          </Container>
           <RightStack stack={rightStack} />
-        </HStack>
+        </Box>
         <Footer />
 
         <ModeSwitch

--- a/src/components/LeftStack/index.tsx
+++ b/src/components/LeftStack/index.tsx
@@ -1,25 +1,38 @@
 /** @jsx jsx */
 
 import { FC } from 'react'
-import { css, jsx } from '@emotion/react'
-import { l_mq } from 'styles/facepaint'
+import { jsx } from '@emotion/react'
+import { Stack } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
 type LeftStackProps = {
   stack?: JSX.Element
 }
 
-const style = css(
-  css`
-    margin-left: 2rem;
-  `,
-  l_mq({
-    width: '256px',
-    display: ['none', 'block'],
-  }),
-)
+const useStyles = makeStyles()({
+  stack: {
+    width: '20vw',
+  },
+})
 
 const LeftStack: FC<LeftStackProps> = ({ stack }) => {
-  return <aside css={style}>{stack ?? null}</aside>
+  const { classes } = useStyles()
+  return (
+    <Stack
+      component="aside"
+      className={classes.stack}
+      sx={{
+        display: {
+          xs: 'none',
+          sm: 'none',
+          md: 'none',
+          lg: 'block',
+        },
+      }}
+    >
+      {stack ?? null}
+    </Stack>
+  )
 }
 
 export default LeftStack

--- a/src/components/Nav/cells/DrawerNavigation.tsx
+++ b/src/components/Nav/cells/DrawerNavigation.tsx
@@ -6,7 +6,6 @@ import { Box, IconButton, SwipeableDrawer, Typography } from '@mui/material'
 import MenuIcon from '@mui/icons-material/MenuRounded'
 import CloseIcon from '@mui/icons-material/CloseRounded'
 import CategoryTable from 'components/CategoryTable'
-import { themeConfigs } from '../../../configuration'
 
 type DrawerNavigationProps = {}
 
@@ -52,11 +51,7 @@ const DrawerNavigation: FC<DrawerNavigationProps> = ({}) => {
               fontSize="small"
             />
           </IconButton>
-          <Typography
-            fontWeight="bold"
-            margin="0 0 10px 10px"
-            color={themeConfigs.light.sub}
-          >
+          <Typography fontWeight="bold" margin="0 0 10px 10px" color="primary">
             카테고리
           </Typography>
           <div

--- a/src/components/Nav/cells/Title.tsx
+++ b/src/components/Nav/cells/Title.tsx
@@ -1,30 +1,37 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/react'
-import { themeConfigs } from '../../../configuration'
+import { jsx } from '@emotion/react'
 import { Link } from 'gatsby'
 import { FC } from 'react'
+import { Box } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
 type TitleCellProps = {
   title: string
 }
 
-const style = css`
-  margin-inline: 2rem;
-  padding: 0.5rem;
-  font-weight: 500;
-  transition: all 0.15s ease;
+const useStyles = makeStyles()(theme => ({
+  root: {
+    marginInline: '2rem',
+    padding: '0.5rem',
+    fontWeight: 500,
+    transition: 'all 0.15s ease',
 
-  :hover {
-    color: ${themeConfigs.light.sub};
-    scale: 105%;
-  }
-`
+    ':hover': {
+      color:
+        theme.palette.mode === 'dark'
+          ? theme.palette.primary.dark
+          : theme.palette.primary.light,
+      scale: '105%',
+    },
+  },
+}))
 
 const TitleCell: FC<TitleCellProps> = ({ title }) => {
+  const { classes } = useStyles()
   return (
-    <Link to="/" css={style}>
-      {title}
+    <Link to="/">
+      <Box className={classes.root}>{title}</Box>
     </Link>
   )
 }

--- a/src/components/RightStack/TableOfContents/cells/TOCTitle.tsx
+++ b/src/components/RightStack/TableOfContents/cells/TOCTitle.tsx
@@ -1,11 +1,15 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/react'
+import { jsx } from '@emotion/react'
 import { Link } from 'gatsby'
 import { FC, useContext } from 'react'
 
 import { ArticleContext } from 'contexts/article/ArticleContext'
+import { Typography } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
+
 import { LIGHT_GRAY } from 'styles/Color'
+import { PAGE_PREFIX } from 'constants/PageConsts'
 
 type TOCTitleProps = {
   title?: string
@@ -13,30 +17,31 @@ type TOCTitleProps = {
   activated?: boolean
 }
 
-const style = (activated?: boolean) => css`
-  position: relative;
-  padding-block: 1px;
-  font-size: 0.9rem;
-  font-weight: 300;
-  left: ${activated ? '-5px' : '0'};
-  transform: ${activated ? 'scale(107%)' : 'scale(100%)'};
-  color: ${activated ? 'black' : LIGHT_GRAY};
+const useStyles = makeStyles<{ activated?: boolean }>()((_, { activated }) => ({
+  tableIndex: {
+    position: 'relative',
+    left: activated ? '-5px' : '0',
+    transform: activated ? 'scale(107%)' : 'scale(100%)',
+    color: activated ? 'primary' : LIGHT_GRAY,
 
-  :hover {
-    color: black;
-  }
+    ':hover': {
+      color: 'primary',
+    },
 
-  transition: color 0.2s ease, left 0.2s ease, transform 0.2s ease;
-`
+    transition: 'color 0.2s ease, left 0.2s ease, transform 0.2s ease',
+  },
+}))
+
 const TOCTitle: FC<TOCTitleProps> = ({ title, url, activated }) => {
+  const { classes } = useStyles({ activated })
   const {
     fields: { slug },
   } = useContext(ArticleContext)
 
   return (
-    <div css={style(activated)}>
-      <Link to={`/posts` + slug + url}>{title}</Link>
-    </div>
+    <Typography component="a" variant="body1" className={classes.tableIndex}>
+      <Link to={PAGE_PREFIX.ARTICLE + slug + url}>{title}</Link>
+    </Typography>
   )
 }
 

--- a/src/components/RightStack/TableOfContents/index.tsx
+++ b/src/components/RightStack/TableOfContents/index.tsx
@@ -1,36 +1,36 @@
 /** @jsx jsx */
 
-import { css, jsx } from '@emotion/react'
+import { jsx } from '@emotion/react'
 import { FC, useContext } from 'react'
 
 import { ArticleContext } from 'contexts/article/ArticleContext'
 import useTableOfContentsObserver from 'hooks/useTableOfContentsObserver'
 
 import TableOfContentsCell from './cells/TableOfContentsCell'
-import { BORDER_MUSK } from 'styles/Color'
+import { Stack } from '@mui/material'
+import { makeStyles } from 'tss-react/mui'
 
 type TableOfContentsProps = {}
 
-const style = css`
-  position: -webkit-sticky;
-  position: sticky;
-  align-self: start;
-  top: 5rem;
-  max-height: calc(100vh - 5rem);
-  overflow: auto;
+const useStyles = makeStyles()({
+  nav: {
+    position: 'sticky',
+    // alignSelf: 'start',
+    top: '5rem',
+    maxHeight: 'calc(100vh - 5rem)',
+    // overflow: 'auto',
+  },
+})
 
-  border-left: 1px solid ${BORDER_MUSK};
-  padding-block: 0.5rem;
-  padding-left: 1rem;
-`
 const TableOfContents: FC<TableOfContentsProps> = () => {
   useTableOfContentsObserver()
   const { tableOfContents } = useContext(ArticleContext)
+  const { classes } = useStyles()
 
   return (
-    <nav css={style}>
+    <Stack component="nav" className={classes.nav}>
       <TableOfContentsCell data={tableOfContents!.root} />
-    </nav>
+    </Stack>
   )
 }
 

--- a/src/components/RightStack/index.tsx
+++ b/src/components/RightStack/index.tsx
@@ -1,25 +1,40 @@
 /** @jsx jsx */
 
 import { css, jsx } from '@emotion/react'
+import { Stack } from '@mui/material'
 import { FC } from 'react'
-import { l_mq } from 'styles/facepaint'
+import { makeStyles } from 'tss-react/mui'
 
 type RightStackProps = {
   stack?: JSX.Element
 }
 
-const style = css(
-  css`
-    margin-right: 2rem;
-  `,
-  l_mq({
-    width: '256px',
-    display: ['none', 'flex'],
-  }),
-)
+const style = css()
+const useStyles = makeStyles()({
+  stack: {
+    width: '20vw',
+  },
+})
 
 const RightStack: FC<RightStackProps> = ({ stack }) => {
-  return <aside css={style}>{stack ?? null}</aside>
+  const { classes } = useStyles()
+  return (
+    <Stack
+      component="aside"
+      css={style}
+      className={classes.stack}
+      sx={{
+        display: {
+          xs: 'none',
+          sm: 'none',
+          md: 'none',
+          lg: 'block',
+        },
+      }}
+    >
+      {stack ?? null}
+    </Stack>
+  )
 }
 
 export default RightStack

--- a/src/styles/designSystem/remark/index.ts
+++ b/src/styles/designSystem/remark/index.ts
@@ -1,46 +1,46 @@
 import styled from '@emotion/styled'
-import { themeConfigs } from '../../../configuration'
 import { BORDER_MUSK, GRAY, LIGHT_GRAY } from 'styles/Color'
+import { teal } from '@mui/material/colors'
 
 // Headers
 export const H1 = styled.h1`
   font-size: 2rem;
-  font-weight: 500;
+  font-weight: 600;
   padding-bottom: 0.2rem;
   border-bottom: 1px solid ${BORDER_MUSK};
 `
 
 export const H2 = styled.h2`
   font-size: 1.7rem;
-  font-weight: 500;
+  font-weight: 600;
   padding-bottom: 0.2rem;
   border-bottom: 1px solid ${BORDER_MUSK};
 `
 
 export const H3 = styled.h3`
   font-size: 1.5rem;
-  font-weight: 500;
+  font-weight: 600;
 `
 
 export const H4 = styled.h4`
   font-size: 1.3rem;
-  font-weight: 500;
+  font-weight: 600;
 `
 
 export const H5 = styled.h5`
   font-size: 1rem;
-  font-weight: 500;
+  font-weight: 600;
 `
 
 // Texts
 export const P = styled.p`
   font-size: 1rem;
-  font-weight: 300;
+  font-weight: 400;
   line-height: 1.6rem;
 `
 
 export const STRONG = styled.strong`
-  font-weight: 500;
+  font-weight: 600;
 `
 
 export const EM = styled.em``
@@ -64,10 +64,10 @@ export const BLOCKQUOTE = styled.blockquote`
 `
 
 export const DEL = styled.del`
-  font-weight: 300;
+  font-weight: 400;
 `
 export const A = styled.a`
-  color: ${themeConfigs.light.sub};
+  color: ${teal[600]};
   text-decoration: underline;
 `
 
@@ -81,7 +81,7 @@ export const OL = styled.ol`
 `
 
 export const LI = styled.li`
-  font-weight: 300;
+  font-weight: 400;
 `
 
 // Tables
@@ -95,7 +95,7 @@ export const TH = styled.th`
 `
 
 export const TD = styled.td`
-  font-weight: 300;
+  font-weight: 400;
   padding-block: 0.3rem;
   padding-inline: 0.5rem;
   border: 0.1px solid ${LIGHT_GRAY};

--- a/src/styles/designSystem/semantic/index.ts
+++ b/src/styles/designSystem/semantic/index.ts
@@ -13,16 +13,16 @@ export const H2 = styled.h2`
 `
 
 export const P = styled.p`
-  font-weight: 300;
+  font-weight: 400;
 `
 
 export const SPAN = styled.span`
-  font-weight: 300;
+  font-weight: 400;
 `
 
 // Semantic tags for Structure
 export const SUMMARY = styled.summary`
-  font-weight: 300;
+  font-weight: 400;
 `
 
 export const ASIDE = styled.aside`

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -1,22 +1,26 @@
-import {
-  PaletteColor,
-  PaletteColorOptions,
-  PaletteMode,
-  createTheme,
-} from '@mui/material'
+import { PaletteColor, PaletteColorOptions, PaletteMode } from '@mui/material'
+import { createTheme } from '@mui/material/styles'
 import { teal } from '@mui/material/colors'
+import { BORDER_MUSK, LIGHT_GRAY } from './Color'
+
+type AdditionalPaletteProperty = 'navbar' | 'category' | 'border' | 'subText'
+
+type AdditionalPalette = {
+  [key in AdditionalPaletteProperty]: PaletteColor
+}
+
+type AdditionalPaletteOptions = {
+  [key in AdditionalPaletteProperty]?: PaletteColorOptions
+}
 
 declare module '@mui/material/styles' {
-  interface Palette {
-    navbar: PaletteColor
-  }
-  interface PaletteOptions {
-    navbar?: PaletteColorOptions
-  }
+  interface Palette extends AdditionalPalette {}
+
+  interface PaletteOptions extends AdditionalPaletteOptions {}
 }
 
 export const configureTheme = (mode: PaletteMode) => {
-  return createTheme({
+  const theme = createTheme({
     palette: {
       primary: {
         main: teal[600],
@@ -25,6 +29,32 @@ export const configureTheme = (mode: PaletteMode) => {
         main: '#146C94',
       },
       mode,
+    },
+  })
+
+  return createTheme(theme, {
+    palette: {
+      category: theme.palette.augmentColor({
+        color: {
+          main: teal[100],
+        },
+      }),
+      navbar: theme.palette.augmentColor({
+        color: {
+          main: '#EBEBEB',
+          dark: '#22262C',
+        },
+      }),
+      border: theme.palette.augmentColor({
+        color: {
+          main: BORDER_MUSK,
+        },
+      }),
+      subText: theme.palette.augmentColor({
+        color: {
+          main: LIGHT_GRAY,
+        },
+      }),
     },
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1237,7 +1237,7 @@
     "@emotion/babel-plugin" "^11.10.0"
     "@emotion/babel-plugin-jsx-pragmatic" "^0.2.0"
 
-"@emotion/cache@^11.10.5", "@emotion/cache@^11.11.0":
+"@emotion/cache@*", "@emotion/cache@^11.10.5", "@emotion/cache@^11.11.0":
   version "11.11.0"
   resolved "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz#809b33ee6b1cb1a625fef7a45bc568ccd9b8f3ff"
   integrity sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==
@@ -1252,6 +1252,11 @@
   version "0.9.0"
   resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.0.tgz"
   integrity sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==
+
+"@emotion/hash@^0.9.1":
+  version "0.9.1"
+  resolved "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
+  integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
 
 "@emotion/is-prop-valid@^1.2.0", "@emotion/is-prop-valid@^1.2.1":
   version "1.2.1"
@@ -1278,6 +1283,17 @@
     "@emotion/utils" "^1.2.0"
     "@emotion/weak-memoize" "^0.3.0"
     hoist-non-react-statics "^3.3.1"
+
+"@emotion/serialize@*":
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz#017a6e4c9b8a803bd576ff3d52a0ea6fa5a62b51"
+  integrity sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==
+  dependencies:
+    "@emotion/hash" "^0.9.1"
+    "@emotion/memoize" "^0.8.1"
+    "@emotion/unitless" "^0.8.1"
+    "@emotion/utils" "^1.2.1"
+    csstype "^3.0.2"
 
 "@emotion/serialize@^1.1.1":
   version "1.1.1"
@@ -1312,12 +1328,17 @@
   resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.0.tgz"
   integrity sha512-VINS5vEYAscRl2ZUDiT3uMPlrFQupiKgHz5AA4bCH1miKBg4qtwkim1qPmJj/4WG6TreYMY111rEFsjupcOKHw==
 
+"@emotion/unitless@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz#182b5a4704ef8ad91bde93f7a860a88fd92c79a3"
+  integrity sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ==
+
 "@emotion/use-insertion-effect-with-fallbacks@^1.0.0":
   version "1.0.0"
   resolved "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz"
   integrity sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==
 
-"@emotion/utils@^1.2.0", "@emotion/utils@^1.2.1":
+"@emotion/utils@*", "@emotion/utils@^1.2.0", "@emotion/utils@^1.2.1":
   version "1.2.1"
   resolved "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz#bbab58465738d31ae4cb3dbb6fc00a5991f755e4"
   integrity sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg==
@@ -12371,6 +12392,15 @@ tslib@~2.4.0:
   version "2.4.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
   integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tss-react@^4.8.8:
+  version "4.8.8"
+  resolved "https://registry.npmjs.org/tss-react/-/tss-react-4.8.8.tgz#80f58ff2fa2c15a4097d0760ea7d8ca327c73104"
+  integrity sha512-V57AU6J42LLhYhRGSxDVi9VLUaoQtV6y2Kb1e0uqabe3w61G9R8gkUiX4DHZUReboRY9rwExPWz0LVZIgqQ98Q==
+  dependencies:
+    "@emotion/cache" "*"
+    "@emotion/serialize" "*"
+    "@emotion/utils" "*"
 
 tsutils@^3.21.0:
   version "3.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2914,6 +2914,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.2.tgz#35654cf6c49ae162d5bc90843d5437dc38008d43"
+  integrity sha512-Icd9KEgdnFfJs39KyRyr0jQ7EKhq8U6CcHRMGAS45fp5qgUvxL3ujUCfWFttUK2UErqZNj97t9gsVPNAqcwoCg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-is@^18.2.1":
   version "18.2.1"
   resolved "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.1.tgz#61d01c2a6fc089a53520c0b66996d458fdc46863"
@@ -2928,22 +2935,12 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "18.2.19"
-  resolved "https://registry.npmjs.org/@types/react/-/react-18.2.19.tgz#f77cb2c8307368e624d464a25b9675fa35f95a8b"
-  integrity sha512-e2S8wmY1ePfM517PqCG80CcE48Xs5k0pwJzuDZsfE8IZRRBfOMCF+XqnFxu6mWtyivum1MQm4aco+WIt6Coimw==
+"@types/react@*", "@types/react@17.0.2", "@types/react@>=16":
+  version "17.0.2"
+  resolved "https://registry.npmjs.org/@types/react/-/react-17.0.2.tgz#3de24c4efef902dd9795a49c75f760cbe4f7a5a8"
+  integrity sha512-Xt40xQsrkdvjn1EyWe1Bc0dJLcil/9x2vAuW7ya+PuQip4UYUaXyhzWmAbwRsdMgwOFHpfp7/FFZebDU6Y8VHA==
   dependencies:
     "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@>=16":
-  version "18.0.26"
-  resolved "https://registry.npmjs.org/@types/react/-/react-18.0.26.tgz"
-  integrity sha512-hCR3PJQsAIXyxhTNSiDFY//LhnMZWpNNr5etoCqx/iUfGc5gXWtQR2Phl908jVR6uPXacojQWTg4qRpkxTuGug==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
     csstype "^3.0.2"
 
 "@types/responselike@^1.0.0":
@@ -2960,11 +2957,6 @@
   dependencies:
     "@types/glob" "*"
     "@types/node" "*"
-
-"@types/scheduler@*":
-  version "0.16.3"
-  resolved "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
-  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/semver@^7.3.12":
   version "7.3.13"
@@ -7241,10 +7233,10 @@ graphql-type-json@0.3.2:
   resolved "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz#f53a851dbfe07bd1c8157d24150064baab41e115"
   integrity sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg==
 
-graphql@^16.6.0:
-  version "16.6.0"
-  resolved "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
-  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+graphql@^16.5.0, graphql@^16.6.0:
+  version "16.7.1"
+  resolved "https://registry.npmjs.org/graphql/-/graphql-16.7.1.tgz#11475b74a7bff2aefd4691df52a0eca0abd9b642"
+  integrity sha512-DRYR9tf+UGU0KOsMcKAlXeFfX89UiiIZ0dRU3mR0yJfu6OjZqUcp68NnFLnqQU5RexygFoDy1EW+ccOYcPfmHg==
 
 gray-matter@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
# 작업 개요
<!-- ex) 고양이가 야옹 소리를 내도록 수정 -->
여전히 mui 마이그레이션 중... 

# 이슈 티켓
<!-- ex) 작업한 이슈를 태그하세요. -->

# 작업 분류

- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ] 설정

# 작업 상세 내용

<!--  ex) 1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴 -->
## [tss-react 의존성 설치](https://github.com/leobang17/gatsby-theme-simplex/commit/854f22a8b19c6a7388c2626e31a62af36d2a3676)
- https://mui.com/material-ui/migration/migrating-from-jss/#2-use-tss-react
- theme 과 함께 이용하기 편한듯

## [tss와 기존 react와의 호환을 위해 resolution 설정](https://github.com/leobang17/gatsby-theme-simplex/commit/3d8897f42906de6a7bc2b3ae35fe5a244a14eeab)

## [mui createtheme 수정](https://github.com/leobang17/gatsby-theme-simplex/commit/707bdbcde0129a89283c6042ba2a3b01bbb0d8cd)
- 커스텀 theme 추가하기 용이하도록

## [mui 및 mui theme 적용](https://github.com/leobang17/gatsby-theme-simplex/commit/cc684dcda0c7b0cae87d0846c100ae41efecbd71)
- category boxes
- tableofcontents
- layouts
- article cards

## [designsystem 폰트 weight 수정](https://github.com/leobang17/gatsby-theme-simplex/commit/cb082fc0d96cb168ae7e9381b1a3addfbaed5027)

## markdown format on save 없애기 (834fe5b496f1072a450840bdde2d0dd67dbd7b76)

# 공유사항

<!-- 1. wav 파일을 매번 입력하기 귀찮겠다. -->
